### PR TITLE
Data Loading Performance Improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ fastavro
 google-api-python-client
 google-cloud-aiplatform
 google-cloud-bigquery
+google-cloud-bigquery-storage
 google-cloud-storage
 numpy
 scipy

--- a/src/casp/bq_scripts/anndata_to_avro.py
+++ b/src/casp/bq_scripts/anndata_to_avro.py
@@ -63,58 +63,33 @@ def write_avro(generator, parsed_schema, filename, progress_batch_size=10000):
             writer(out, parsed_schema, records)
 
 
-def dump_core_matrix(row_array, col_array, data_array, row_offset, cas_cell_index_start, cas_feature_index_start, filename):
+def dump_core_matrix(
+    row_array, col_array, data_array, row_offset, cas_cell_index_start, cas_feature_index_start, filename
+):
     """
     Write the raw X matrix.
     """
-    # schema = {
-    #     "doc": "Raw data indexed by cell and feature id in the CAS BigQuery schema",
-    #     "namespace": "cas",
-    #     "name": "CellFeature",
-    #     "type": "record",
-    #     "fields": [
-    #         {"name": "cas_cell_index", "type": "int"},
-    #         {"name": "cas_feature_index", "type": "int"},
-    #         {"name": "raw_counts", "type": "int"},
-    #     ],
-    # }
-    # parsed_schema = parse_schema(schema)
     start = current_milli_time()
-    #lg=row_lookup_d.get
-    #rows = np.vectorize(lg)(row_array + row_offset)
+    # lg=row_lookup_d.get
+    # rows = np.vectorize(lg)(row_array + row_offset)
     rows = row_array + row_offset + cas_cell_index_start
-    print(f"    {filename} - Vectorize row lookup... in {current_milli_time() - start} ms")    
+    print(f"    {filename} - Vectorize row lookup... in {current_milli_time() - start} ms")
     start = current_milli_time()
-    #cols = np.vectorize(col_lookup_d.get)(col_array)
-    #cols = [ col_lookup[i] for i in col_array ]
+    # cols = np.vectorize(col_lookup_d.get)(col_array)
+    # cols = [ col_lookup[i] for i in col_array ]
     cols = col_array + cas_feature_index_start
     print(f"    {filename} - Processing {len(data_array)} elements")
-    
-    print(f"    {filename} - Vectorize col lookup... in {current_milli_time() - start} ms")    
+
+    print(f"    {filename} - Vectorize col lookup... in {current_milli_time() - start} ms")
     start = current_milli_time()
     i_dat = data_array.astype(int)
-    print(f"    {filename} - Convert types... in {current_milli_time() - start} ms")    
+    print(f"    {filename} - Convert types... in {current_milli_time() - start} ms")
 
-    # def raw_counts_generator():
-    #     for row, col, dat in zip(rows, cols, i_dat):
-    #         yield {
-    #             "cas_cell_index": row,
-    #             "cas_feature_index": col,
-    #             "raw_counts": dat,
-    #         }
-
-    # write_avro(raw_counts_generator, parsed_schema, filename, progress_batch_size=1000000)
-    # i =0
-    # for row, col, dat in zip(rows, cols, i_dat):
-    #     i = i + 1
     start = current_milli_time()
     with open(filename, "w") as out:
-      for row, col, dat in zip(rows, cols, i_dat):
-        out.write(f"{row},{col},{dat}\n")
-    print(f"    {filename} - Write Chunk... in {current_milli_time() - start} ms")    
-
-    # with open(filename, "a+b") as out:
-    #      writer(out, parsed_schema, raw_counts_generator(), sync_interval=160000)
+        for row, col, dat in zip(rows, cols, i_dat):
+            out.write(f"{row},{col},{dat}\n")
+    print(f"    {filename} - Write Chunk... in {current_milli_time() - start} ms")
 
 
 def dump_cell_info(adata, filename, cas_cell_index_start, ingest_id):
@@ -123,10 +98,6 @@ def dump_cell_info(adata, filename, cas_cell_index_start, ingest_id):
     """
     adata.obs["original_cell_id"] = adata.obs.index
     adata.obs["cas_cell_index"] = np.arange(cas_cell_index_start, cas_cell_index_start + len(adata.obs))
-
-    # row_index_to_cas_cell_index = [None] * len(adata.obs)
-    # for row in range(0, len(adata.obs)):
-    #     row_index_to_cas_cell_index[row] = adata.obs["cas_cell_index"].iloc[[row]][0]
 
     schema = {
         "doc": "CAS Cell Info",
@@ -160,8 +131,6 @@ def dump_cell_info(adata, filename, cas_cell_index_start, ingest_id):
 
     write_avro(cell_generator, parsed_schema, filename)
 
-#    return row_index_to_cas_cell_index
-
 
 def dump_feature_info(adata, filename, cas_feature_index_start, ingest_id):
     """
@@ -169,10 +138,6 @@ def dump_feature_info(adata, filename, cas_feature_index_start, ingest_id):
     """
     adata.var["original_feature_id"] = adata.var.index
     adata.var["cas_feature_index"] = np.arange(cas_feature_index_start, cas_feature_index_start + len(adata.var))
-
-    col_index_to_cas_feature_index = [None] * len(adata.var)
-    for col in range(0, len(adata.var)):
-        col_index_to_cas_feature_index[col] = adata.var["cas_feature_index"].iloc[[col]][0]
 
     schema = {
         "doc": "CAS Feature Info",
@@ -205,7 +170,7 @@ def dump_feature_info(adata, filename, cas_feature_index_start, ingest_id):
             }
 
     write_avro(feature_generator, parsed_schema, filename)
-    return col_index_to_cas_feature_index
+    # return col_index_to_cas_feature_index
 
 
 def dump_ingest_info(adata, filename, ingest_id, load_uns_data):
@@ -326,7 +291,7 @@ def find_max_index(client, project, dataset, table, column):
     return max_id
 
 
-def process(input_file, cas_cell_index_start, cas_feature_index_start, avro_prefix, project, dataset, load_uns_data):
+def process(input_file, cas_cell_index_start, cas_feature_index_start, prefix, project, dataset, load_uns_data):
     """
     High level entry point, reads the input AnnData file and generates Avro files
     for ingest, cells, features, and raw / core data.
@@ -345,18 +310,23 @@ def process(input_file, cas_cell_index_start, cas_feature_index_start, avro_pref
         cas_feature_index_start = find_max_index(client, project, dataset, "cas_feature_info", "cas_feature_index") + 1
         print(f"cas_feature_index_start will be {cas_feature_index_start}")
 
-    avro_prefix = "cas" if not avro_prefix else avro_prefix
+    prefix = "cas" if not prefix else prefix
     print(f"Hashing input AnnData file '{input_file}' to generate ingest id...")
     ingest_id = f"cas-ingest-{md5(input_file)[:8]}"
     print(f"Generated ingest id '{ingest_id}'.")
 
     file_types = ["ingest_info", "cell_info", "feature_info", "raw_counts"]
-    filenames = [f"{avro_prefix}_{file_type}.avro" for file_type in file_types]
+    filenames = [f"{prefix}_{file_type}.avro" for file_type in file_types]
     confirm_output_files_do_not_exist(filenames)
+
     (ingest_filename, cell_filename, feature_filename, raw_counts_filename) = filenames
 
+    ingest_filename = f"{prefix}_ingest_info.avro"
+    cell_filename = f"{prefix}_cell_info.avro"
+    feature_filename = f"{prefix}_feature_info.avro"
+    ingest_filename = f"{prefix}_raw_counts.avro"
+
     print(f"Loading input AnnData file '{input_file}'...")
-    #adata = ad.read(input_file, backed='r')
     adata = optimized_read_andata(input_file)
 
     print("Processing ingest metadata...")
@@ -370,13 +340,9 @@ def process(input_file, cas_cell_index_start, cas_feature_index_start, avro_pref
 
     print("Processing core data...")
 
-    # recode the indexes to be the indexes of obs/var or should obs/var include these indices?
-    # row_lookup_d = dict(enumerate(row_index_to_cas_cell_index))
-    # col_lookup_d = dict(enumerate(col_index_to_cas_feature_index))
-
     total_cells = adata.raw.X.shape[0]
 
-    # try closing 
+    # close and attempt to free memory
     adata.file.close()
     del adata
     gc.collect()
@@ -385,54 +351,44 @@ def process(input_file, cas_cell_index_start, cas_feature_index_start, avro_pref
     num_batches = math.ceil(total_cells / batch_size)
 
     # ranges are start-inclusive and end-exclusive
-    batches = [ (x, x*batch_size, min(total_cells, x*batch_size + batch_size))  for x in range(num_batches)]
-  
+    batches = [(x, x * batch_size, min(total_cells, x * batch_size + batch_size)) for x in range(num_batches)]
+
     start = current_milli_time()
     with multiprocessing.get_context("spawn").Pool() as pool:
         args = []
         for (index, row_offset, end) in batches:
-            chunk_raw_counts_filename = raw_counts_filename.replace(".avro",f".{index:06}.csv")
-            args.append([input_file, row_offset, end, cas_cell_index_start, cas_feature_index_start, chunk_raw_counts_filename])
+            chunk_raw_counts_filename = raw_counts_filename.replace(".avro", f".{index:06}.csv")
+            args.append(
+                [input_file, row_offset, end, cas_cell_index_start, cas_feature_index_start, chunk_raw_counts_filename]
+            )
 
         for result in pool.map(p_dump_core_matrix, args, chunksize=1):
-            print(f'Got result: {result} for {args}', flush=True)
-    
-    print(f"    Processed {total_cells} cells... in {current_milli_time() - start} ms")    
+            print(f"Got result: {result} for {args}", flush=True)
+
+    print(f"    Processed {total_cells} cells... in {current_milli_time() - start} ms")
 
     print("Done.")
 
-# handle any errors in the task function
-def custom_error_callback(error):
-    print(f'Got an Error: {error}', flush=True)
 
-def p_dump_core_matrix(args):
+def process_dump_core_matrix(args):
     start = current_milli_time()
 
     (input_file, row_offset, end, cas_cell_index_start, cas_feature_index_start, raw_counts_filename) = args
     coord = optimized_read_raw_X(input_file, row_offset, end)
-#    adata = ad.read(input_file, backed='r')
-#    coord = adata.raw.X[row_offset:end, :].tocoo()
-#    adata.file.close()
-#    del adata
-#    gc.collect()
-    print(f"    {raw_counts_filename} - Read anndata, subset matrix... in {current_milli_time() - start} ms")    
+    print(f"    {raw_counts_filename} - Read anndata, subset matrix... in {current_milli_time() - start} ms")
 
-    dump_core_matrix(coord.row, coord.col, coord.data, row_offset, cas_cell_index_start, cas_feature_index_start, raw_counts_filename)
+    dump_core_matrix(
+        coord.row, coord.col, coord.data, row_offset, cas_cell_index_start, cas_feature_index_start, raw_counts_filename
+    )
 
-# TODO: naive dump, compare
-#    rows,cols = adata.X.nonzero()
-#    for row,col in zip(rows,cols):
-#        cas_cell_index = row_index_to_cas_cell_index[row]
-#        cas_feature_index = col_index_to_cas_feature_index[col]
-#        v = adata.X[row,col]
 
 # based on implementation of https://github.com/scverse/anndata/blob/6473f2034aa6e28ebc826ceeab15f413b8d294d8/anndata/_io/h5ad.py#L119
 # optimized for reading of subset of raw.X
 def optimized_read_andata(input_file):
-    f = h5py.File(input_file, 'r')
+    f = h5py.File(input_file, "r")
 
     attributes = ["obs", "var"]
-    d = dict(filename=input_file, filemode='r')
+    d = dict(filename=input_file, filemode="r")
     d.update({k: read_elem(f[k]) for k in attributes if k in f})
 
     d["raw"] = _read_raw(f, attrs={"var", "varm"})
@@ -441,7 +397,8 @@ def optimized_read_andata(input_file):
     if isinstance(f["obs"], h5py.Dataset):
         _clean_uns(d)
 
-    return AnnData(**d)    
+    return AnnData(**d)
+
 
 def optimized_read_raw_X(input_file, row_offset, end):
     adata = optimized_read_andata(input_file)
@@ -451,6 +408,7 @@ def optimized_read_raw_X(input_file, row_offset, end):
     gc.collect()
     return coord
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         allow_abbrev=False, description="Convert AnnData Single Cell Expression Data into format for loading into BQ"
@@ -458,9 +416,9 @@ if __name__ == "__main__":
 
     parser.add_argument("--input", type=str, help="AnnData format input file", required=True)
     parser.add_argument(
-        "--avro_prefix",
+        "--prefix",
         type=str,
-        help="Prefix to use for output Avro files, e.g. <avro_prefix>_cell_info.avro etc",
+        help="Prefix to use for output files, e.g. <prefix>_cell_info.avro etc",
         required=False,
     )
     parser.add_argument("--cas_cell_index_start", type=int, help="starting number for cell index", required=False)
@@ -494,7 +452,7 @@ if __name__ == "__main__":
         args.input,
         args.cas_cell_index_start,
         args.cas_feature_index_start,
-        args.avro_prefix,
+        args.prefix,
         args.project,
         args.dataset,
         args.load_uns_data,

--- a/src/casp/bq_scripts/anndata_to_avro.py
+++ b/src/casp/bq_scripts/anndata_to_avro.py
@@ -224,7 +224,7 @@ def dump_ingest_info(adata, filename, ingest_id, load_uns_data):
         if load_uns_data is True:
             for idx, uncapped_val in adata.uns.data.items():
                 uncapped_json = json.dumps(uncapped_val, cls=NumpyEncoder)
-                if len(uncapped_json) > metadata_limit:
+                if len(uncapped_json) > metadata_limit: 
                     print(
                         f"AnnData `uns` contains a key `{idx}` whose JSONified value would have size {len(uncapped_json)} bytes."
                     )
@@ -369,9 +369,7 @@ if __name__ == "__main__":
     parser.add_argument("--flush_batch_size", type=int, help="max size of Avro batches to flush", required=False)
     parser.add_argument("--project", type=str, help="BigQuery Project", required=False)
     parser.add_argument("--dataset", type=str, help="BigQuery Dataset", required=False)
-    parser.add_argument(
-        "--load_uns_data", help="load uns (unstructured) metadata", default="False", action="store_true"
-    )
+    parser.add_argument("--load_uns_data", help="load uns (unstructured) metadata", default="False", action='store_true')    
 
     args = parser.parse_args()
 
@@ -398,5 +396,5 @@ if __name__ == "__main__":
         args.avro_prefix,
         args.project,
         args.dataset,
-        args.load_uns_data,
+        args.load_uns_data
     )

--- a/src/casp/bq_scripts/anndata_to_avro.py
+++ b/src/casp/bq_scripts/anndata_to_avro.py
@@ -224,7 +224,7 @@ def dump_ingest_info(adata, filename, ingest_id, load_uns_data):
         if load_uns_data is True:
             for idx, uncapped_val in adata.uns.data.items():
                 uncapped_json = json.dumps(uncapped_val, cls=NumpyEncoder)
-                if len(uncapped_json) > metadata_limit: 
+                if len(uncapped_json) > metadata_limit:
                     print(
                         f"AnnData `uns` contains a key `{idx}` whose JSONified value would have size {len(uncapped_json)} bytes."
                     )
@@ -369,7 +369,9 @@ if __name__ == "__main__":
     parser.add_argument("--flush_batch_size", type=int, help="max size of Avro batches to flush", required=False)
     parser.add_argument("--project", type=str, help="BigQuery Project", required=False)
     parser.add_argument("--dataset", type=str, help="BigQuery Dataset", required=False)
-    parser.add_argument("--load_uns_data", help="load uns (unstructured) metadata", default="False", action='store_true')    
+    parser.add_argument(
+        "--load_uns_data", help="load uns (unstructured) metadata", default="False", action="store_true"
+    )
 
     args = parser.parse_args()
 
@@ -396,5 +398,5 @@ if __name__ == "__main__":
         args.avro_prefix,
         args.project,
         args.dataset,
-        args.load_uns_data
+        args.load_uns_data,
     )

--- a/src/casp/bq_scripts/anndata_to_avro.py
+++ b/src/casp/bq_scripts/anndata_to_avro.py
@@ -9,23 +9,19 @@ version 0.1.
 """
 
 import argparse
+import gc
 import hashlib
-import itertools
 import json
 import math
 import multiprocessing
 import os
 import time
-import gc
 
 import h5py
-from anndata._io.specs import read_elem, write_elem
-from anndata._io.h5ad import _read_raw
-from anndata._core.anndata import AnnData
-
-
-import anndata as ad
 import numpy as np
+from anndata._core.anndata import AnnData
+from anndata._io.h5ad import _read_raw, _clean_uns
+from anndata._io.specs import read_elem
 from fastavro import parse_schema, writer
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
@@ -362,7 +358,7 @@ def process(input_file, cas_cell_index_start, cas_feature_index_start, prefix, p
                 [input_file, row_offset, end, cas_cell_index_start, cas_feature_index_start, chunk_raw_counts_filename]
             )
 
-        for result in pool.map(p_dump_core_matrix, args, chunksize=1):
+        for result in pool.map(process_dump_core_matrix, args, chunksize=1):
             print(f"Got result: {result} for {args}", flush=True)
 
     print(f"    Processed {total_cells} cells... in {current_milli_time() - start} ms")

--- a/src/casp/bq_scripts/load_dataset.py
+++ b/src/casp/bq_scripts/load_dataset.py
@@ -149,7 +149,7 @@ def process(project, dataset, avro_prefix, gcs_path_prefix):
 
     input_file_types = ["ingest_info", "cell_info", "feature_info", "raw_counts"]
     input_filenames = [f"{avro_prefix}_{file_type}.avro" for file_type in input_file_types]
-##    confirm_input_files_exist(input_filenames)
+    ##    confirm_input_files_exist(input_filenames)
     ingest_filename, cell_filename, feature_filename, raw_counts_filename = input_filenames
     raw_counts_pattern = f"{avro_prefix}_raw_counts.*.csv"
 
@@ -172,9 +172,9 @@ def process(project, dataset, avro_prefix, gcs_path_prefix):
     staged_files = []
     gcs_path_prefix = gcs_path_prefix.rstrip("/")
     pairs = [
-       ("ingest_info", ingest_filename, bigquery.SourceFormat.AVRO),
-       ("cell_info", cell_filename, bigquery.SourceFormat.AVRO),
-       ("feature_info", feature_filename, bigquery.SourceFormat.AVRO),
+        ("ingest_info", ingest_filename, bigquery.SourceFormat.AVRO),
+        ("cell_info", cell_filename, bigquery.SourceFormat.AVRO),
+        ("feature_info", feature_filename, bigquery.SourceFormat.AVRO),
         ("raw_count_matrix", raw_counts_pattern, bigquery.SourceFormat.CSV),
     ]
     job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.AVRO)

--- a/src/casp/bq_scripts/load_dataset.py
+++ b/src/casp/bq_scripts/load_dataset.py
@@ -7,6 +7,7 @@
 """
 
 import argparse
+import glob
 import os
 import re
 
@@ -148,8 +149,9 @@ def process(project, dataset, avro_prefix, gcs_path_prefix):
 
     input_file_types = ["ingest_info", "cell_info", "feature_info", "raw_counts"]
     input_filenames = [f"{avro_prefix}_{file_type}.avro" for file_type in input_file_types]
-    confirm_input_files_exist(input_filenames)
+##    confirm_input_files_exist(input_filenames)
     ingest_filename, cell_filename, feature_filename, raw_counts_filename = input_filenames
+    raw_counts_pattern = f"{avro_prefix}_raw_counts.*.csv"
 
     # Grab the `cas_ingest_id` from the ingest file.
     with open(ingest_filename, "rb") as file:
@@ -170,21 +172,24 @@ def process(project, dataset, avro_prefix, gcs_path_prefix):
     staged_files = []
     gcs_path_prefix = gcs_path_prefix.rstrip("/")
     pairs = [
-        ("ingest_info", ingest_filename),
-        ("cell_info", cell_filename),
-        ("feature_info", feature_filename),
-        ("raw_count_matrix", raw_counts_filename),
+       ("ingest_info", ingest_filename, bigquery.SourceFormat.AVRO),
+       ("cell_info", cell_filename, bigquery.SourceFormat.AVRO),
+       ("feature_info", feature_filename, bigquery.SourceFormat.AVRO),
+        ("raw_count_matrix", raw_counts_pattern, bigquery.SourceFormat.CSV),
     ]
     job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.AVRO)
 
-    for table, file in pairs:
+    for table, file_pattern, format in pairs:
         table = f"cas_{table}"
         table_id = f"{project}.{dataset}.{table}"
 
-        stage_file(file)
-        staged_files.append(file)
+        for file in glob.glob(file_pattern):
+            stage_file(file)
+            staged_files.append(file)
 
-        uri = f"{gcs_path_prefix}/{file}"
+        uri = f"{gcs_path_prefix}/{file_pattern}"
+        job_config = bigquery.LoadJobConfig(source_format=format)
+
         load_job = client.load_table_from_uri(uri, table_id, job_config=job_config)  # Make an API request.
         result = load_job.result()  # Waits for the job to complete.
         print(f"{result.output_rows} rows loaded into BigQuery table '{table_id}'.")

--- a/src/casp/bq_scripts/load_dataset.py
+++ b/src/casp/bq_scripts/load_dataset.py
@@ -149,7 +149,9 @@ def process(project, dataset, avro_prefix, gcs_path_prefix):
 
     input_file_types = ["ingest_info", "cell_info", "feature_info", "raw_counts"]
     input_filenames = [f"{avro_prefix}_{file_type}.avro" for file_type in input_file_types]
-    ##    confirm_input_files_exist(input_filenames)
+
+    # TODO: reimplement
+    # confirm_input_files_exist(input_filenames)
     ingest_filename, cell_filename, feature_filename, raw_counts_filename = input_filenames
     raw_counts_pattern = f"{avro_prefix}_raw_counts.*.csv"
 


### PR DESCRIPTION
Changes:

* AVRO is very slow and CPU intensive in Python.  Switched to CSV for core data type (matrix).  Left as AVRO for cell/obs
*  Changed matrix index -> cas index from a lookup (slow) to a vectorized calculation (fast)
* Used multi-processing to process sub-sections of the raw data matrix in parallel 
*  Overall attempt to reduce memory pressure by closing files, deleting references and garbage collecting 
* Optimized methods for reading reading just raw counts data from AnnData files `optimized_read_andata` and `optimized_read_raw_X`


Data: gs://dsp-cell-annotation-service/dec_2022_demo/h5ad/