### PR TITLE
DB connection pool size increase

### DIFF
--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -34,6 +34,10 @@ class AllEnvSettings(BaseSettings):
     JWT_HASHING_ALGORITHM: str = "HS256"
     JWT_DEFAULT_TOKEN_TTL: int = 60 * 60 * 24 * 180  # 180 days
     # Database
+    DB_CONNECTION_POOL_SIZE: int = 50  # 50 connections
+    DB_CONNECTION_POOL_MAX_OVERFLOW: int = 10  # 10 connections
+    DB_CONNECTION_POOL_TIMEOUT: int = 40  # 40 seconds
+    DB_CONNECTION_POOL_RECYCLE: int = 1800  # 30 minutes
     DB_NAME: str = os.environ.get("DB_NAME")
     DB_PASSWORD: str = os.environ.get("DB_PASSWORD")
     DB_USER: str = os.environ.get("DB_USER")

--- a/src/casp/services/api/README.md
+++ b/src/casp/services/api/README.md
@@ -36,14 +36,19 @@ PROJECT_ID=dsp-cell-annotation-service
 gcloud run deploy cas-api \
 --project $PROJECT_ID \
 --image $IMAGE_NAME \
---memory 2Gi \
---region us-central1 \
---platform managed \
---port 8000 \
+--cpu=1 \
+--memory=4Gi \
+--region=us-central1 \
+--platform=managed \
+--port=8000 \
 --allow-unauthenticated \
---vpc-connector cas-ai-matching \
---add-cloudsql-instances=dsp-cell-annotation-service:us-central1:cas-db-cluster \
---command python --args "casp/services/api/server.py"
+--vpc-connector=cas-ai-matching \
+--add-cloudsql-instances=dsp-cell-annotation-service:us-central1:cas-db-cluster-2 \
+--timeout=1100 \
+--max-instances=500 \
+--min-instances=0 \
+--concurrency=20 \
+--command=python --args="casp/services/api/server.py"
 
 
 BASE_URL="https://cas-api-vi7nxpvk7a-uc.a.run.app:8000"

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -5,10 +5,10 @@ from casp.services import settings
 
 engine = sqlalchemy.create_engine(
     url=settings.SQLALCHEMY_DATABASE_URI,
-    pool_size=5,
-    max_overflow=2,
-    pool_timeout=30,  # 30 seconds
-    pool_recycle=1800,  # 30 minutes
+    pool_size=settings.DB_CONNECTION_POOL_SIZE,
+    max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
+    pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
+    pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 db_session = scoped_session(SessionLocal)

--- a/src/casp/services/model_inference/README.md
+++ b/src/casp/services/model_inference/README.md
@@ -12,13 +12,19 @@ docker push $IMAGE_NAME
 IMAGE_NAME=us-east4-docker.pkg.dev/dsp-cell-annotation-service/casp-pca/casp_pca_service:1.0
 PROJECT_ID=dsp-cell-annotation-service
 
-gcloud run deploy cas-inference-service \
---project $PROJECT_ID \
---image $IMAGE_NAME \
---memory 2Gi \
---region us-central1 \
---platform managed \
---port 8000 \
+gcloud run deploy cas-model \
+--project=$PROJECT_ID \
+--image=$IMAGE_NAME \
+--memory=4Gi \
+--cpu=1 \
+--region=us-central1 \
+--platform=managed \
+--port=8000 \
 --allow-unauthenticated \
+--add-cloudsql-instances=dsp-cell-annotation-service:us-central1:cas-db-cluster-2 \
+--timeout=1100 \
+--max-instances=500 \
+--min-instances=0 \
+--concurrency=10 \
 --command python --args "casp/services/model_inference/server.py"
 ```


### PR DESCRIPTION
To allow larger throughput in the system, we need a larger DB connection Pool size. This is the current database connection overload on large datasets.
<img width="623" alt="image" src="https://github.com/cellarium-ai/cellarium-cloud/assets/26435815/4cbb21cf-a4ae-4d46-a740-8c62a0103c5e">
Possible solutions to increase throughput:
1. Implement caching (good for large-scale apps, CAS doesn't look like the one so far).
2. Aggregate write requests. A new issue for this (#110)
3. Increasing database SQL server machine requirements (number of CPUs, RAM). Already did it. In the cloud
4. Increase Database [connection pool](https://en.wikipedia.org/wiki/Connection_pool) size
It seems that neither RAM or CPUs are utilized well, while the number of maximum connections is reaching its limits which (imho) means that the database could easily afford an increase in connection pool size.
<img width="1092" alt="image" src="https://github.com/cellarium-ai/cellarium-cloud/assets/26435815/b6db437e-e99c-42e0-bba1-5f3e14acea9b">
