### PR TITLE
Enforce Python >= 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is intended to hold the functional prototype for a single cell a
 
 ### Prerequisites / Installation
 
- - Python 3.7+
+ - Python 3.10+
 
 ### Developer Setup
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=long_description,
     install_requires=install_requires,
     tests_require=["coverage", "pytest"],
-    python_requires=">=3.7",
+    python_requires=">=3.10",
     packages=find_packages("src"),
     package_dir={"": "src"},
     classifiers=[
@@ -28,9 +28,6 @@ setup(
         "Intended Audience :: Science/Research",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
     ],


### PR DESCRIPTION
The repo has a dependency on Cellarium.ML which currently [requires python 3.10](https://github.com/cellarium-ai/cellarium-ml/blob/55a902cca9945cadef90d2300f2f7b9258b921e2/pyproject.toml#L13).  Additionally, Cell Ranger is on 3.10 and for a variety of reasons having one python version makes life easier.