### PR TITLE
Tracking user requests and cells processed in separate user activity table

### DIFF
--- a/src/casp/data_manager/base_data_manager.py
+++ b/src/casp/data_manager/base_data_manager.py
@@ -1,7 +1,7 @@
 from google.cloud import bigquery
 
 from casp.services import utils
-from casp.services.db import init_db
+from casp.services.db import get_db_session_maker
 
 
 class BaseDataManager:
@@ -24,4 +24,4 @@ class BaseDataManager:
         self.credentials = credentials
         self.project = project
         self.block_coo_matrix_db_client = bigquery.Client(credentials=self.credentials, project=self.project)
-        self.system_data_db_session = init_db()
+        self.system_data_db_session_maker = get_db_session_maker()

--- a/src/casp/services/_auth/jwt_token.py
+++ b/src/casp/services/_auth/jwt_token.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 
 from casp.services import settings
 from casp.services._auth import exceptions
-from casp.services.db import models
+from casp.services.db import models, get_db_session_maker
 
 
 def generate_jwt_for_user(user_id: int, token_ttl: int = settings.JWT_DEFAULT_TOKEN_TTL) -> str:
@@ -46,7 +46,8 @@ def authenticate_user_with_jwt(token: str) -> models.User:
     if datetime.now() >= expiration_date:
         raise exceptions.TokenExpired
     try:
-        return models.User.query.get(user_id)
+        with get_db_session_maker()() as session:
+            return session.query(models.User).get(user_id)
     except IntegrityError as e:
         logging.error(e)
         raise exceptions.TokenInvalid

--- a/src/casp/services/_auth/jwt_token.py
+++ b/src/casp/services/_auth/jwt_token.py
@@ -6,7 +6,7 @@ from sqlalchemy.exc import IntegrityError
 
 from casp.services import settings
 from casp.services._auth import exceptions
-from casp.services.db import models, get_db_session_maker
+from casp.services.db import get_db_session_maker, models
 
 
 def generate_jwt_for_user(user_id: int, token_ttl: int = settings.JWT_DEFAULT_TOKEN_TTL) -> str:

--- a/src/casp/services/admin/__init__.py
+++ b/src/casp/services/admin/__init__.py
@@ -6,7 +6,7 @@ from casp.services import db, settings
 flask_app = Flask(__name__)
 flask_app.config.from_object(settings)
 basic_auth = HTTPBasicAuth()
-db_session = db.init_db()
+db_session = db.get_db_session_maker()
 
 
 @basic_auth.verify_password

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -124,9 +124,9 @@ class UserAdminView(CellariumCloudAdminModelView):
         EndpointLinkRowAction("glyphicon glyphicon-asterisk", ".generate_secret_key"),
         LinkRowAction("glyphicon glyphicon-duplicate", "clone?id={row_id}"),
     ]
-    column_list = ("email", "is_admin", "is_active", "requests_processed", "cells_processed")
+    column_list = ("email", "is_admin", "is_active", "total_requests_processed", "total_cells_processed")
     column_editable_list = ("is_admin",)
-    form_widget_args = {"requests_processed": {"disabled": True}, "cells_processed": {"disabled": True}}
+    form_excluded_columns = ("requests_processed", "cells_processed")
 
     @staticmethod
     def _create_token_file(token) -> tempfile.NamedTemporaryFile:

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -12,8 +12,9 @@ from werkzeug.exceptions import HTTPException
 
 from casp.services import _auth
 from casp.services.admin import basic_auth, flask_app
-from casp.services.db import db_session, models, ops
+from casp.services.db import get_db_session_maker, models, ops
 
+db_session = get_db_session_maker()()
 
 class AuthException(HTTPException):
     def __init__(self, message):

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -16,6 +16,7 @@ from casp.services.db import get_db_session_maker, models, ops
 
 db_session = get_db_session_maker()()
 
+
 class AuthException(HTTPException):
     def __init__(self, message):
         super().__init__(

--- a/src/casp/services/api/data_manager/cellarium_general.py
+++ b/src/casp/services/api/data_manager/cellarium_general.py
@@ -87,8 +87,7 @@ class CellariumGeneralDataManager(BaseDataManager):
 
             return model
 
-    @classmethod
-    def get_index_for_model(cls, model_name: str) -> models.CASMatchingEngineIndex:
+    def get_index_for_model(self, model_name: str) -> models.CASMatchingEngineIndex:
         """
         Retrieve CAS model index by its system name
 
@@ -96,7 +95,14 @@ class CellariumGeneralDataManager(BaseDataManager):
 
         :return: CAS ML model index object from the database
         """
-        return cls.get_model_by_name(model_name=model_name).cas_matching_engine
+
+        with self.system_data_db_session_maker() as session:
+            model = session.query(models.CASModel).filter_by(model_name=model_name).first()
+
+            if model is None:
+                raise exceptions.NotFound(f"Model {model_name} not found in the database")
+            
+            return model.cas_matching_engine
     
     def log_user_activity(self, user_id: int, model_name: str, method: str, cell_count: int) -> None:
         """

--- a/src/casp/services/api/data_manager/cellarium_general.py
+++ b/src/casp/services/api/data_manager/cellarium_general.py
@@ -116,6 +116,5 @@ class CellariumGeneralDataManager(BaseDataManager):
         user_activity = models.UserActivity(
             user_id=user_id, model_name=model_name, method=method, cell_count=cell_count
         )
-        with self.system_data_db_session_maker() as session:
-            with session.begin():
-                session.add(user_activity)
+        with self.system_data_db_session_maker.begin() as session:
+            session.add(user_activity)

--- a/src/casp/services/api/data_manager/cellarium_general.py
+++ b/src/casp/services/api/data_manager/cellarium_general.py
@@ -101,9 +101,9 @@ class CellariumGeneralDataManager(BaseDataManager):
 
             if model is None:
                 raise exceptions.NotFound(f"Model {model_name} not found in the database")
-            
+
             return model.cas_matching_engine
-    
+
     def log_user_activity(self, user_id: int, model_name: str, method: str, cell_count: int) -> None:
         """
         Log the information to the DB about a request from a user
@@ -113,7 +113,9 @@ class CellariumGeneralDataManager(BaseDataManager):
         :param method: Method that user is using
         :param cell_count: Number of cells processed in this request
         """
-        user_activity = models.UserActivity(user_id=user_id, model_name=model_name, method=method, cell_count=cell_count)
+        user_activity = models.UserActivity(
+            user_id=user_id, model_name=model_name, method=method, cell_count=cell_count
+        )
         with self.system_data_db_session_maker() as session:
             with session.begin():
                 session.add(user_activity)

--- a/src/casp/services/api/services/cell_operations_service.py
+++ b/src/casp/services/api/services/cell_operations_service.py
@@ -218,20 +218,25 @@ class CellOperationsService:
         :return: JSON response with annotations.
         """
         self.authorize_model_for_user(user=user, model_name=model_name)
-        query_ids, embeddings = await CellOperationsService.get_embeddings(file_to_embed=file, model_name=model_name)
+        """
+        TODO: Return this to the way it was once we have been able to replicate the bug
 
+        query_ids, embeddings = await self.get_embeddings(file_to_embed=file, model_name=model_name)
+        
         if embeddings.size == 0:
             # No further processing needed if there are no embeddings
             return []
-        knn_response = await self.get_knn_matches(embeddings=embeddings, model_name=model_name)
+        knn_response = self.get_knn_matches(embeddings=embeddings, model_name=model_name)
         annotation_response = self.get_cell_type_distribution(
             query_ids=query_ids,
             knn_response=knn_response,
             model_name=model_name,
             include_dev_metadata=include_dev_metadata,
-        )
-        self.cellarium_general_dm.increment_user_cells_processed(user=user, number_of_cells=len(query_ids))
-        return annotation_response
+        """
+        #self.cellarium_general_dm.increment_user_cells_processed(user=user, number_of_cells=random.randint(1, 1000))
+        self.cellarium_general_dm.log_user_activity(user_id=user.id, model_name=model_name, method="annotate", cell_count=random.randint(1, 1000))
+        # return annotation_response
+        return []
 
     async def search_adata_file(
         self, user: models.User, file: t.BinaryIO, model_name: str

--- a/src/casp/services/api/services/cell_operations_service.py
+++ b/src/casp/services/api/services/cell_operations_service.py
@@ -224,7 +224,7 @@ class CellOperationsService:
         if embeddings.size == 0:
             # No further processing needed if there are no embeddings
             return []
-        knn_response = self.get_knn_matches(embeddings=embeddings, model_name=model_name)
+        knn_response = await self.get_knn_matches(embeddings=embeddings, model_name=model_name)
         annotation_response = self.get_cell_type_distribution(
             query_ids=query_ids,
             knn_response=knn_response,

--- a/src/casp/services/api/services/cell_operations_service.py
+++ b/src/casp/services/api/services/cell_operations_service.py
@@ -218,8 +218,6 @@ class CellOperationsService:
         :return: JSON response with annotations.
         """
         self.authorize_model_for_user(user=user, model_name=model_name)
-        """
-        TODO: Return this to the way it was once we have been able to replicate the bug
 
         query_ids, embeddings = await self.get_embeddings(file_to_embed=file, model_name=model_name)
         
@@ -232,11 +230,9 @@ class CellOperationsService:
             knn_response=knn_response,
             model_name=model_name,
             include_dev_metadata=include_dev_metadata,
-        """
-        #self.cellarium_general_dm.increment_user_cells_processed(user=user, number_of_cells=random.randint(1, 1000))
-        self.cellarium_general_dm.log_user_activity(user_id=user.id, model_name=model_name, method="annotate", cell_count=random.randint(1, 1000))
-        # return annotation_response
-        return []
+        )
+        self.cellarium_general_dm.log_user_activity(user_id=user.id, model_name=model_name, method="annotate", cell_count=len(query_ids))
+        return annotation_response
 
     async def search_adata_file(
         self, user: models.User, file: t.BinaryIO, model_name: str

--- a/src/casp/services/api/services/cell_operations_service.py
+++ b/src/casp/services/api/services/cell_operations_service.py
@@ -220,7 +220,7 @@ class CellOperationsService:
         self.authorize_model_for_user(user=user, model_name=model_name)
 
         query_ids, embeddings = await self.get_embeddings(file_to_embed=file, model_name=model_name)
-        
+
         if embeddings.size == 0:
             # No further processing needed if there are no embeddings
             return []
@@ -231,7 +231,9 @@ class CellOperationsService:
             model_name=model_name,
             include_dev_metadata=include_dev_metadata,
         )
-        self.cellarium_general_dm.log_user_activity(user_id=user.id, model_name=model_name, method="annotate", cell_count=len(query_ids))
+        self.cellarium_general_dm.log_user_activity(
+            user_id=user.id, model_name=model_name, method="annotate", cell_count=len(query_ids)
+        )
         return annotation_response
 
     async def search_adata_file(

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -14,7 +14,6 @@ db_session_maker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 
 
-
 def get_db_session_maker() -> sessionmaker:
     import casp.services.db.models  # noqa
 

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -1,5 +1,5 @@
 import sqlalchemy.orm
-from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 from casp.services import settings
 

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -10,18 +10,12 @@ engine = sqlalchemy.create_engine(
     pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
     pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
 )
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-db_session = scoped_session(SessionLocal)
+db_session_maker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
-Base.query = db_session.query_property()
 
 
-def save(record) -> None:
-    db_session.add(record)
-    db_session.commit()
 
-
-def init_db() -> sqlalchemy.orm.scoped_session:
+def get_db_session_maker() -> sessionmaker:
     import casp.services.db.models  # noqa
 
-    return db_session
+    return db_session_maker

--- a/src/casp/services/db/migrations/env.py
+++ b/src/casp/services/db/migrations/env.py
@@ -4,9 +4,9 @@ from alembic import context
 from sqlalchemy import engine_from_config, pool
 
 from casp.services import settings
-from casp.services.db import Base, init_db
+from casp.services.db import Base, get_db_session_maker
 
-init_db()
+get_db_session_maker()
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
+++ b/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
@@ -5,30 +5,34 @@ Revises: 0009
 Create Date: 2024-03-27 17:00:17.459888
 
 """
-from alembic import op
-import sqlalchemy as sa
 
+import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '310657f0e46c'
-down_revision = 'a2e0ae902a06'
+revision = "310657f0e46c"
+down_revision = "a2e0ae902a06"
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table('user_activity',
-        sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('user_id', sa.Integer(), nullable=True),
-        sa.Column('cell_count', sa.Integer(), nullable=False),
-        sa.Column('model_name', sa.String(length=255), nullable=False),
-        sa.Column('method', sa.String(length=255), nullable=True),
-        sa.Column('finished_time', sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.PrimaryKeyConstraint('id'),
-        sa.Index('ix_user_activity_user_id', 'user_id', unique=False)
+    op.create_table(
+        "user_activity",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=True),
+        sa.Column("cell_count", sa.Integer(), nullable=False),
+        sa.Column("model_name", sa.String(length=255), nullable=False),
+        sa.Column("method", sa.String(length=255), nullable=True),
+        sa.Column("finished_time", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.Index("ix_user_activity_user_id", "user_id", unique=False),
     )
 
 
 def downgrade() -> None:
-    op.drop_table('user_activity')
+    op.drop_table("user_activity")

--- a/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
+++ b/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '310657f0e46c'
-down_revision = '0009'
+down_revision = 'a2e0ae902a06'
 branch_labels = None
 depends_on = None
 

--- a/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
+++ b/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
@@ -25,7 +25,8 @@ def upgrade() -> None:
         sa.Column('method', sa.String(length=255), nullable=True),
         sa.Column('finished_time', sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.PrimaryKeyConstraint('id')
+        sa.PrimaryKeyConstraint('id'),
+        sa.Index('ix_user_activity_user_id', 'user_id', unique=False)
     )
 
 

--- a/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
+++ b/src/casp/services/db/migrations/versions/t_2024-03-27_17-00-17_user_activity.py
@@ -1,0 +1,33 @@
+"""user_activity
+
+Revision ID: 310657f0e46c
+Revises: 0009
+Create Date: 2024-03-27 17:00:17.459888
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '310657f0e46c'
+down_revision = '0009'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table('user_activity',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('cell_count', sa.Integer(), nullable=False),
+        sa.Column('model_name', sa.String(length=255), nullable=False),
+        sa.Column('method', sa.String(length=255), nullable=True),
+        sa.Column('finished_time', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('user_activity')

--- a/src/casp/services/db/models.py
+++ b/src/casp/services/db/models.py
@@ -21,6 +21,18 @@ class User(db.Base):
         return self.email
 
 
+class UserActivity(db.Base):
+    id = sa.Column(sa.Integer, primary_key=True)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey(f"{User.__tablename__}.id"))
+    cell_count = sa.Column(sa.Integer, default=0, nullable=False)
+    model_name = sa.Column(sa.String(255), nullable=False)
+    method = sa.Column(sa.String(255), nullable=True)
+    finished_time = sa.Column(sa.DateTime, default=datetime.datetime.now(datetime.timezone.utc))
+
+    __tablename__ = "user_activity"
+
+
+
 class CASModel(db.Base):
     id = sa.Column(sa.Integer, primary_key=True)
     model_name = sa.Column(sa.String(255), unique=True, nullable=False)

--- a/src/casp/services/db/models.py
+++ b/src/casp/services/db/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 import sqlalchemy as sa
-from sqlalchemy.orm import backref, relationship
+from sqlalchemy.orm import backref, relationship, column_property
 
 from casp.services import db, settings
 
@@ -65,3 +65,21 @@ class CASMatchingEngineIndex(db.Base):
         return self.index_name
 
     __tablename__ = "cas_matching_engine_index"
+
+# Add properties to user model for metrics
+sa.inspect(User).add_property(
+    key="total_cells_processed",
+    prop=column_property(
+        User.cells_processed+ sa.select(sa.func.sum(UserActivity.cell_count))
+        .where(UserActivity.user_id == User.id)
+        .scalar_subquery()
+    )
+)
+sa.inspect(User).add_property(
+    key="total_requests_processed",
+    prop=column_property(
+        User.requests_processed + sa.select(sa.func.count(UserActivity.id))
+        .where(UserActivity.user_id == User.id)
+        .scalar_subquery()
+    )
+)

--- a/src/casp/services/db/models.py
+++ b/src/casp/services/db/models.py
@@ -32,7 +32,6 @@ class UserActivity(db.Base):
     __tablename__ = "user_activity"
 
 
-
 class CASModel(db.Base):
     id = sa.Column(sa.Integer, primary_key=True)
     model_name = sa.Column(sa.String(255), unique=True, nullable=False)

--- a/src/casp/services/db/models.py
+++ b/src/casp/services/db/models.py
@@ -1,7 +1,7 @@
 import datetime
 
 import sqlalchemy as sa
-from sqlalchemy.orm import backref, relationship, column_property
+from sqlalchemy.orm import backref, column_property, relationship
 
 from casp.services import db, settings
 
@@ -66,20 +66,19 @@ class CASMatchingEngineIndex(db.Base):
 
     __tablename__ = "cas_matching_engine_index"
 
+
 # Add properties to user model for metrics
 sa.inspect(User).add_property(
     key="total_cells_processed",
     prop=column_property(
-        User.cells_processed+ sa.select(sa.func.sum(UserActivity.cell_count))
-        .where(UserActivity.user_id == User.id)
-        .scalar_subquery()
-    )
+        User.cells_processed
+        + sa.select(sa.func.sum(UserActivity.cell_count)).where(UserActivity.user_id == User.id).scalar_subquery()
+    ),
 )
 sa.inspect(User).add_property(
     key="total_requests_processed",
     prop=column_property(
-        User.requests_processed + sa.select(sa.func.count(UserActivity.id))
-        .where(UserActivity.user_id == User.id)
-        .scalar_subquery()
-    )
+        User.requests_processed
+        + sa.select(sa.func.count(UserActivity.id)).where(UserActivity.user_id == User.id).scalar_subquery()
+    ),
 )

--- a/src/casp/services/db/ops.py
+++ b/src/casp/services/db/ops.py
@@ -1,4 +1,4 @@
-from casp.services.db import db_session, models
+from casp.services.db import get_db_session_maker, models
 
 
 def set_default_model_by(model_id: int) -> None:
@@ -6,7 +6,7 @@ def set_default_model_by(model_id: int) -> None:
     Change system's default CAS model. Changes is_default_model by id and sets all other models being default to False
     :param model_id: ID of the model
     """
-    models.CASModel.query.update({models.CASModel.is_default_model: False})
-    db_session.commit()
-    models.CASModel.query.filter_by(id=model_id).update({models.CASModel.is_default_model: True})
-    db_session.commit()
+    with get_db_session_maker()() as db_session:
+        with db_session.begin():
+            models.CASModel.query.update({models.CASModel.is_default_model: False})
+            models.CASModel.query.filter_by(id=model_id).update({models.CASModel.is_default_model: True})

--- a/src/casp/services/db/ops.py
+++ b/src/casp/services/db/ops.py
@@ -8,5 +8,5 @@ def set_default_model_by(model_id: int) -> None:
     """
     with get_db_session_maker()() as db_session:
         with db_session.begin():
-            models.CASModel.query.update({models.CASModel.is_default_model: False})
-            models.CASModel.query.filter_by(id=model_id).update({models.CASModel.is_default_model: True})
+            db_session.query(models.CASModel).update({models.CASModel.is_default_model: False})
+            db_session.query(models.CASModel).filter_by(id=model_id).update({models.CASModel.is_default_model: True})

--- a/src/casp/services/db/ops.py
+++ b/src/casp/services/db/ops.py
@@ -6,7 +6,6 @@ def set_default_model_by(model_id: int) -> None:
     Change system's default CAS model. Changes is_default_model by id and sets all other models being default to False
     :param model_id: ID of the model
     """
-    with get_db_session_maker()() as db_session:
-        with db_session.begin():
-            db_session.query(models.CASModel).update({models.CASModel.is_default_model: False})
-            db_session.query(models.CASModel).filter_by(id=model_id).update({models.CASModel.is_default_model: True})
+    with get_db_session_maker().begin() as db_session:
+        db_session.query(models.CASModel).update({models.CASModel.is_default_model: False})
+        db_session.query(models.CASModel).filter_by(id=model_id).update({models.CASModel.is_default_model: True})

--- a/src/casp/services/model_inference/data_managers.py
+++ b/src/casp/services/model_inference/data_managers.py
@@ -9,8 +9,7 @@ class ModelInferenceDataManager(BaseDataManager):
     Data Manager for accessing data within the scope of model inference.
     """
 
-    @staticmethod
-    def get_model_by(model_name: str) -> t.Optional[models.CASModel]:
+    def get_model_by(self, model_name: str) -> t.Optional[models.CASModel]:
         """
         Get a specific model by its unique name
 
@@ -18,4 +17,5 @@ class ModelInferenceDataManager(BaseDataManager):
 
         :return: CAS model object
         """
-        return models.CASModel.query.filter_by(model_name=model_name).first()
+        with self.system_data_db_session_maker() as session:
+            return session.query(models.CASModel).filter_by(model_name=model_name).first()

--- a/tests/unit/test_cell_operations_service.py
+++ b/tests/unit/test_cell_operations_service.py
@@ -167,12 +167,12 @@ class TestCellOperationsService:
 
         # if there are no embeddings, then we should not increment the number of cells processed
         if len(embeddings) == 0:
-            verify(self.cell_operations_service.cellarium_general_dm, times=0).increment_user_cells_processed(
-                user=ANY, number_of_cells=ANY
+            verify(self.cell_operations_service.cellarium_general_dm, times=0).log_user_activity(
+                user=ANY, model_name=ANY, method=ANY, cell_count=ANY
             )
         else:
-            verify(self.cell_operations_service.cellarium_general_dm).increment_user_cells_processed(
-                user=USER_ADMIN, number_of_cells=len(embeddings)
+            verify(self.cell_operations_service.cellarium_general_dm).log_user_activity(
+                user_id=USER_ADMIN.id, model_name=MODEL.model_name, method="annotate", cell_count=len(query_ids)
             )
 
     @parameterized.expand(


### PR DESCRIPTION
Changes in this PR:

- Added a new table, user_activity, which keeps track of cell_count for each user annotation request, along with some metadata about the request.
- Now using the sqlalchemy `with session.begin():` syntax for any insert and update operations into the DB for transactions
- Creating sessions from the session maker for logically-grouped database operations
  - I might have overdone it here.  I think it makes sense to not just have the one session, but I wonder if maybe it would be better to have one session per request or something.

To do:

- Need to update the admin interface to display the proper counts for cells processed and requests processed on the user page