### PR TITLE
CAS-25 Support communicating with postgres over VPC

### DIFF
--- a/docs/source/modules/running_locally.rst
+++ b/docs/source/modules/running_locally.rst
@@ -28,7 +28,6 @@ Once the Admin service is running, you can visit `Admin Dashboard <http://127.0.
 
 To run commands that require accessing the vector search API using gRPC, you will need to create a tunnel.  To do this you
 must:
-- log into the Broad non-split VPN
 - log into the gcloud cli with the command ``gcloud auth login``
 
 You can then run the following command to create a tunnel:

--- a/docs/source/modules/secrets.rst
+++ b/docs/source/modules/secrets.rst
@@ -25,6 +25,8 @@ created manually.
 +------------------------------------+-----------------------------------------------------------------------+
 | DB_PASSWORD                        | Password for the database                                             |
 +------------------------------------+-----------------------------------------------------------------------+
+| DB_PRIVATE_IP                      | Private IP for the Cloud SQL DB                                       |
++------------------------------------+-----------------------------------------------------------------------+
 | DB_CONNECTION_NAME                 | Connection name for the database (Not needed for local env)           |
 +------------------------------------+-----------------------------------------------------------------------+
 | DB_INSTANCE_UNIX_SOCKET            | Unix socket for the database (Not needed for local env)               |

--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -74,7 +74,7 @@ class AllEnvSettings(BaseSettings):
     DB_USER: str = os.environ.get("DB_USER")
     DB_INSTANCE_UNIX_SOCKET: str = os.environ.get("DB_INSTANCE_UNIX_SOCKET")
     DB_PORT: str = os.environ.get("DB_PORT")
-    # If this is value is specified, if will be usedd isntead of the unix socket
+    # If this is value is specified, it will be used instead of the unix socket
     DB_PRIVATE_IP: str = os.environ.get("DB_PRIVATE_IP")
     # BigQuery
     BQ_SQL_TEMPLATES_DIR: str = f"{CAS_DIR}/datastore_manager/sql/templates"

--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -68,16 +68,25 @@ class AllEnvSettings(BaseSettings):
     DB_CONNECTION_POOL_MAX_OVERFLOW: int = 10  # 10 connections
     DB_CONNECTION_POOL_TIMEOUT: int = 40  # 40 seconds
     DB_CONNECTION_POOL_RECYCLE: int = 1800  # 30 minutes
+    DB_CONNECTION_NAME: str = os.environ.get("DB_CONNECTION_NAME")
     DB_NAME: str = os.environ.get("DB_NAME")
     DB_PASSWORD: str = os.environ.get("DB_PASSWORD")
     DB_USER: str = os.environ.get("DB_USER")
     DB_INSTANCE_UNIX_SOCKET: str = os.environ.get("DB_INSTANCE_UNIX_SOCKET")
+    DB_PORT: str = os.environ.get("DB_PORT")
+    # If this is value is specified, if will be usedd isntead of the unix socket
+    DB_PRIVATE_IP: str = os.environ.get("DB_PRIVATE_IP")
     # BigQuery
     BQ_SQL_TEMPLATES_DIR: str = f"{CAS_DIR}/datastore_manager/sql/templates"
-    # Stage db connector through unix socket
-    SQLALCHEMY_DATABASE_URI: str = (
-        f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@/{DB_NAME}?unix_sock={DB_INSTANCE_UNIX_SOCKET}/.s.PGSQL.5432"
-    )
+    # Stage db connector through unix socket or private IP
+    if DB_PRIVATE_IP is None:
+        SQLALCHEMY_DATABASE_URI: str = (
+            f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@/{DB_NAME}?unix_sock={DB_INSTANCE_UNIX_SOCKET}/.s.PGSQL.5432"
+        )
+    else:
+        SQLALCHEMY_DATABASE_URI: str = (
+            f"postgresql+pg8000://{DB_USER}:{DB_PASSWORD}@{DB_PRIVATE_IP}:{DB_PORT}/{DB_NAME}"
+        )
     # Admin
     SECRET_KEY: str = os.environ.get("FLASK_SECRET_KEY")
     SECURITY_PASSWORD_SALT: str = os.environ.get("FLASK_SECURITY_PASSWORD_SALT")

--- a/src/casp/services/admin/README.rst
+++ b/src/casp/services/admin/README.rst
@@ -47,3 +47,23 @@ To deploy the Docker image using Cloud Run run (see `Cloud Run Documentation <ht
     --command=casp/services/admin/entrypoint.sh \
     --platform managed \
     --allow-unauthenticated
+
+Accessing the Service
+---------------------
+The service is behind a firewall and not exposed to the public internet.  It can only be accessed by the internal or if you create 
+a tunnel through the bastion host. To create a tunnel:
+
+log into the gcloud cli with the command:
+.. code-block:: bash
+
+    gcloud auth login
+
+then run the following command:
+
+.. code-block:: bash
+
+    gcloud compute ssh --zone "us-central1-a" "bastion" --project "dsp-cell-annotation-service" --ssh-flag="-D 9090" --ssh-flag="-N"
+
+To use the proxy, you can configure your browser to use the SOCKS proxy at localhost:9090 (or whatever port you specified in the command above).
+
+When you are done, you can close the tunnel by stopping the ssh command in the terminal.

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -27,7 +27,6 @@ def create_engine() -> sqlalchemy.engine.base.Engine:
         return sqlalchemy.create_engine(
             url="postgresql+pg8000://",
             creator=get_private_connection,
-            # pool_pre_ping=True,
             pool_size=settings.DB_CONNECTION_POOL_SIZE,
             max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
             pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -1,16 +1,52 @@
+import pg8000
 import sqlalchemy.orm
+from google.cloud.sql.connector import Connector, IPTypes
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from casp.services import settings
 
-engine = sqlalchemy.create_engine(
-    url=settings.SQLALCHEMY_DATABASE_URI,
-    pool_size=settings.DB_CONNECTION_POOL_SIZE,
-    max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
-    pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
-    pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
-    echo=settings.ENVIRONMENT == "local",
-)
+# initialize Cloud SQL Python Connector object
+connector = Connector()
+
+
+def get_private_connection() -> pg8000.dbapi.Connection:
+    conn: pg8000.dbapi.Connection = connector.connect(
+        instance_connection_string=settings.DB_CONNECTION_NAME,
+        driver="pg8000",
+        user=settings.DB_USER,
+        password=settings.DB_PASSWORD,
+        db=settings.DB_NAME,
+        enable_iam_auth=False,
+        ip_type=IPTypes.PRIVATE,
+    )
+    return conn
+
+
+def create_engine() -> sqlalchemy.engine.base.Engine:
+    if settings.DB_PRIVATE_IP is not None:
+        return sqlalchemy.create_engine(
+            url="postgresql+pg8000://",
+            creator=get_private_connection,
+            # pool_pre_ping=True,
+            pool_size=settings.DB_CONNECTION_POOL_SIZE,
+            max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
+            pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
+            pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
+        )
+
+    else:
+        return sqlalchemy.create_engine(
+            url=settings.SQLALCHEMY_DATABASE_URI,
+            pool_size=settings.DB_CONNECTION_POOL_SIZE,
+            max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
+            pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
+            pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
+            echo=settings.ENVIRONMENT == "local",
+        )
+
+
+engine = create_engine()
+
 db_session_maker = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/src/casp/services/db/migrations/env.py
+++ b/src/casp/services/db/migrations/env.py
@@ -1,10 +1,9 @@
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
 
 from casp.services import settings
-from casp.services.db import Base, get_db_session_maker
+from casp.services.db import Base, create_engine, get_db_session_maker
 
 get_db_session_maker()
 
@@ -61,12 +60,8 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
 
+    connectable = create_engine()
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
 

--- a/src/casp/services/model_inference/README.rst
+++ b/src/casp/services/model_inference/README.rst
@@ -60,3 +60,23 @@ To deploy the Docker image using Cloud Run run (see `Cloud Run Documentation <ht
     --command python --args "casp/services/model_inference/main.py" \
     --allow-unauthenticated \
     --platform=managed
+
+Accessing the Service
+---------------------
+The service is behind a firewall and not exposed to the public internet.  It can only be accessed by the internal or if you create 
+a tunnel through the bastion host. To create a tunnel:
+
+log into the gcloud cli with the command:
+.. code-block:: bash
+
+    gcloud auth login
+
+then run the following command:
+
+.. code-block:: bash
+
+    gcloud compute ssh --zone "us-central1-a" "bastion" --project "dsp-cell-annotation-service" --ssh-flag="-D 9090" --ssh-flag="-N"
+
+To use the proxy, you can configure your browser to use the SOCKS proxy at localhost:9090 (or whatever port you specified in the command above).
+
+When you are done, you can close the tunnel by stopping the ssh command in the terminal.


### PR DESCRIPTION
This PR adds the ability to connect to cloud sql postgres using its private IP, which is over our VPC.  That's needed if we want to run the model and admin services behind the VPC (which we do)

This functionality is enabled when the `DB_PRIVATE_IP` field is specified

This also documents how to connect to the services when they are not exposed to the internet.

My deployments are configured with this so you can check out how it works there.
