### PR TITLE
CAS-25 Deploy CAS from GitHub Action

### DIFF
--- a/.github/actions/docker-deploy/action.yml
+++ b/.github/actions/docker-deploy/action.yml
@@ -30,9 +30,11 @@ inputs:
   deployment-project:
     required: true
     description: The project to deploy the image to
-  deployment-service-account:
+  deployment-service-account-email:
     required: true
-    description: The service account used as the identity for the deployment
+    description: |
+      The service account used as the identity for the deployment.  This is the account that must be granted access to Google cloud
+      resources that CAS services will be using (e.g. buckets)
   deployment-sql-instance:
     required: true
     description: The SQL instance to connect to in the form [project]:[region]:[instance]
@@ -152,7 +154,7 @@ runs:
           --min-instances ${{ env.MIN_INSTANCES }}
           --concurrency ${{ env.CONCURRENCY }}
           --port 8000
-          --service-account ${{ inputs.deployment-service-account }}
+          --service-account ${{ inputs.deployment-service-account-email }}
           --ingress ${{ env.INGRESS }}
           --command ${{ env.COMMAMD }}
           --args "${{ env.ARGS }}"

--- a/.github/actions/docker-deploy/action.yml
+++ b/.github/actions/docker-deploy/action.yml
@@ -134,6 +134,9 @@ runs:
           /app/settings/.env=${{ inputs.deployment-config-secret }}
         secrets_update_strategy: overwrite
         skip_default_labels: true
+        labels: |
+          deployment-prefix=${{ inputs.deployment-prefix }}
+          deployed-by=${{ github.actor }}
         env_vars: |
           MODEL_SERVER_URL=${{ env.MODEL_SERVER_URL }}
         flags: |

--- a/.github/actions/docker-deploy/action.yml
+++ b/.github/actions/docker-deploy/action.yml
@@ -1,0 +1,169 @@
+name: Deploy Docker Image to Cloud Run
+description: Deploy a docker image using Cloud Run.  This will override any deployment with the same prefix.  Returns the URL of the deployed image as `deployed-url`.
+inputs:
+  docker-registry-name:
+    required: true
+    description: GCP Docker Registry name
+  gcp-provider-id:
+    required: true
+    description: CAS GCP Provider ID
+  gcp-service-account-email:
+    required: true
+    description: CAS Deployer Service Account email
+  image-name:
+    required: true
+    description: Name of the image to deploy
+  image-tag:
+    required: true
+    description: Tag of the image to deploy
+  deployment-type:
+    required: true
+    description: The type of deployment to create (cas-model, cas-admin, cas-api)
+  deployment-prefix:
+    required: true
+    description: The prefix to add to the deployment name
+  deployment-flavor:
+    required: true
+    description: |
+      The nature of the deployment set.  E.g. is is a default or large deployment.  Configurations are set based on this value and
+      the values can be configured in the src/casp/services/deploy/cloudrun/{flavor}.json files.
+  deployment-project:
+    required: true
+    description: The project to deploy the image to
+  deployment-service-account:
+    required: true
+    description: The service account used as the identity for the deployment
+  deployment-sql-instance:
+    required: true
+    description: The SQL instance to connect to in the form [project]:[region]:[instance]
+  deployment-vpc-connector:
+    required: true
+    description: The VPC connector to use for the deployment in the form projects/[project]/locations/[region]/connectors/[connector]
+  deployment-config-secret:
+    required: true
+    description: The secret to use for the deployment configuration in the form [secret-name]:[version (or "latest")]
+  deployment-region:
+    required: false
+    description: The region to deploy the image to
+    default: us-central1
+
+runs:
+  using: "composite"
+  steps:
+    - id: checkout
+      name: Checkout
+      uses: actions/checkout@v4
+
+    - id: google-login
+      name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ inputs.gcp-provider-id }}
+        service_account: ${{ inputs.gcp-service-account-email }}
+        access_token_lifetime: 1500s
+
+    - id: docker-google-login
+      name: Login to Artifact Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.docker-registry-name }}
+        username: oauth2accesstoken
+        password: ${{ steps.google-login.outputs.access_token }}
+
+    - id: get-fixed-deloyment-specific-config
+      name: Get fixed deployment specific configuration
+      run: |
+        case "${{ inputs.deployment-type }}" in
+          cas-admin)
+            echo "COMMAMD=casp/services/admin/entrypoint.sh" >> $GITHUB_ENV
+            echo "ARGS=" >> $GITHUB_ENV
+            echo "INGRESS=internal" >> $GITHUB_ENV
+            ;;
+          cas-model)
+            echo "COMMAMD=python" >> $GITHUB_ENV
+            echo "ARGS=casp/services/model_inference/main.py" >> $GITHUB_ENV
+            echo "INGRESS=internal" >> $GITHUB_ENV
+            ;;
+          cas-api)
+            echo "COMMAMD=python" >> $GITHUB_ENV
+            echo "ARGS=casp/services/api/main.py" >> $GITHUB_ENV
+            echo "INGRESS=all" >> $GITHUB_ENV
+            ;;
+          *)
+            echo "Invalid deployment type `${{ inputs.deployment-type }}`"
+            exit 1
+            ;;
+        esac
+      shell: bash
+    
+    - id: get-dynamic-deloyment-specific-config
+      name: Get dynamic deployment specific configuration
+      run: |
+        import json, os
+        def get_strict(json: dict, key: str) -> str:
+          value = json.get(key)
+          if value is None:
+            raise ValueError(f"Key {key} not found in json.")
+          return value
+
+        try:
+          with open("src/casp/services/deploy/cloudrun/${{ inputs.deployment-flavor }}.json", "r") as file:
+            data = json.load(file)
+            deployment_type = get_strict(data, "${{ inputs.deployment-type }}")
+          with open(os.getenv("GITHUB_ENV"), "a") as file_env:
+            file_env.write(f"""MEMORY={get_strict(deployment_type, "memory")}\n""")
+            file_env.write(f"""CPU={get_strict(deployment_type, "cpu")}\n""")
+            file_env.write(f"""MIN_INSTANCES={get_strict(deployment_type, "min-instances")}\n""")
+            file_env.write(f"""MAX_INSTANCES={get_strict(deployment_type, "max-instances")}\n""")
+            file_env.write(f"""CONCURRENCY={get_strict(deployment_type, "concurrency")}\n""")
+        except FileNotFoundError:
+          raise Exception("File not found for flavor ${{ inputs.deployment-flavor }}.")
+
+      shell: python
+    
+    - id: deploy
+      name: Deploy to Cloud Run
+      uses: google-github-actions/deploy-cloudrun@v2
+      with:
+        service: ${{ inputs.deployment-prefix }}-${{ inputs.deployment-type }}
+        image: ${{ inputs.image-name }}:${{ inputs.image-tag }}
+        region: ${{ inputs.deployment-region }}
+        project_id: ${{ inputs.deployment-project }}
+        secrets: |-
+          /app/settings/.env=${{ inputs.deployment-config-secret }}
+        secrets_update_strategy: overwrite
+        skip_default_labels: true
+        env_vars: |
+          MODEL_SERVER_URL=${{ env.MODEL_SERVER_URL }}
+        flags: |
+          --add-cloudsql-instances ${{ inputs.deployment-sql-instance }}
+          --vpc-connector ${{ inputs.deployment-vpc-connector }}
+          --vpc-egress all
+          --allow-unauthenticated
+          --memory ${{ env.MEMORY }}
+          --cpu ${{ env.CPU }}
+          --cpu-boost
+          --timeout 500s
+          --max-instances ${{ env.MAX_INSTANCES }}
+          --min-instances ${{ env.MIN_INSTANCES }}
+          --concurrency ${{ env.CONCURRENCY }}
+          --port 8000
+          --service-account ${{ inputs.deployment-service-account }}
+          --ingress ${{ env.INGRESS }}
+          --command ${{ env.COMMAMD }}
+          --args "${{ env.ARGS }}"
+
+    - id: log-information-summary
+      name: Log URL
+      run: |
+        echo "Deployed [${{ inputs.deployment-prefix }}-${{ inputs.deployment-type }}](${{ steps.deploy.outputs.url }})" >> $GITHUB_STEP_SUMMARY
+      shell: bash
+
+    - id: set-model-url
+      name: We need to stash the URL for the model server for downstream deployments
+      run: |
+        if [[ "${{ inputs.deployment-type }}" == "cas-model" ]]; then
+          echo "MODEL_SERVER_URL=${{ steps.deploy.outputs.url }}" >> $GITHUB_ENV
+        fi
+      shell: bash

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -1,0 +1,117 @@
+name: CAS Repository Deploy Workflow
+on: 
+  workflow_dispatch:
+    inputs:
+      image-tag:
+        description: 'Docker image tag. If empty, the latest version will be used.'
+        required: false
+        default: ''
+      deployment-prefix:
+        description: 'The prefix to add to the deployment names'
+        required: true
+        default: ''
+      service-account-email:
+        description: 'Service account email used as the identity for the deployment.'
+        required: true
+        default: ''
+      sql-instance:
+        description: 'The SQL instance to connect to in the form [project]:[region]:[instance]'
+        required: true
+        default: ''
+      vpc-connector:
+        description: 'The VPC connector to use for the deployment in the form projects/[project]/locations/[region]/connectors/[connector]'
+        required: true
+        default: ''
+      config-secret:
+        description: 'The Google secret to use for the deployment configuration in the form [secret-name]:[version (or "latest")]'
+        required: true
+        default: ''
+      region:
+        description: 'The region to deploy the image to'
+        required: false
+        default: 'us-central1'
+      flavor:
+        description: 'The nature of the deployment set.  E.g. is is a default or large deployment.  Configurations are set based on this value and the values can be configured in the src/casp/services/deploy/cloudrun/{flavor}.json files.'
+        required: true
+        default: 'default'
+jobs:
+
+  deploy-services:
+    name: Deploy CAS Services
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    env:
+      DOCKER_REGISTRY_NAME: us-central1-docker.pkg.dev
+      PYTORCH_IMAGE_NAME: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cas-services-cicd/cas-pytorch
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: get-image-tag
+        name: Get tag
+        run: |
+          if [[ "${{ inputs.image-tag }}" == "" ]]; then
+            echo "IMAGE_TAG=latest" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ inputs.image-tag }}" >> $GITHUB_ENV
+          fi
+        shell: bash
+      - id: deploy-admin
+        name: Deploy the CAS Admin Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-admin
+          deployment-prefix: ${{ inputs.deployment-prefix }}
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: ${{ inputs.flavor }}
+
+      - id: deploy-model
+        name: Deploy the CAS Model Inference Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-model
+          deployment-prefix: ${{ inputs.deployment-prefix }}
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: ${{ inputs.flavor }}
+
+      - id: deploy-api
+        name: Deploy the CAS API Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-api
+          deployment-prefix: ${{ inputs.deployment-prefix }}
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: ${{ inputs.flavor }}

--- a/.github/workflows/deploy-workflow.yml
+++ b/.github/workflows/deploy-workflow.yml
@@ -31,7 +31,7 @@ on:
         required: false
         default: 'us-central1'
       flavor:
-        description: 'The nature of the deployment set.  E.g. is is a default or large deployment.  Configurations are set based on this value and the values can be configured in the src/casp/services/deploy/cloudrun/{flavor}.json files.'
+        description: 'The nature of the deployment set.  E.g. is it a default or large deployment.  Configurations are set based on this value and the values can be configured in the src/casp/services/deploy/cloudrun/{flavor}.json files.'
         required: true
         default: 'default'
 jobs:
@@ -71,7 +71,7 @@ jobs:
           deployment-type: cas-admin
           deployment-prefix: ${{ inputs.deployment-prefix }}
           deployment-project: ${{ secrets.GCP_PROJECT_ID }}
-          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
           deployment-sql-instance: ${{ inputs.sql-instance }}
           deployment-vpc-connector: ${{ inputs.vpc-connector }}
           deployment-config-secret: ${{ inputs.config-secret }}
@@ -90,7 +90,7 @@ jobs:
           deployment-type: cas-model
           deployment-prefix: ${{ inputs.deployment-prefix }}
           deployment-project: ${{ secrets.GCP_PROJECT_ID }}
-          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
           deployment-sql-instance: ${{ inputs.sql-instance }}
           deployment-vpc-connector: ${{ inputs.vpc-connector }}
           deployment-config-secret: ${{ inputs.config-secret }}
@@ -109,7 +109,7 @@ jobs:
           deployment-type: cas-api
           deployment-prefix: ${{ inputs.deployment-prefix }}
           deployment-project: ${{ secrets.GCP_PROJECT_ID }}
-          deployment-service-account: ${{ inputs.service-account-email }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
           deployment-sql-instance: ${{ inputs.sql-instance }}
           deployment-vpc-connector: ${{ inputs.vpc-connector }}
           deployment-config-secret: ${{ inputs.config-secret }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ google-cloud-bigquery-storage==2.19.1
 google-cloud-storage
 scipy
 fastapi==0.96.0
-uvicorn[standard]
+uvicorn[standard]==0.29.0
 python-dotenv
 pyarrow
 python-multipart

--- a/src/casp/services/README.rst
+++ b/src/casp/services/README.rst
@@ -66,9 +66,42 @@ Or by running with the Github client using the following command:
 
     gh workflow run docker-workflow.yml --repo cellarium-ai/cellarium-cloud \
             --ref $GIT_REF \
-            -f image-types=$IMAGE_TYPES
-            -f image-tag=$IMAGE_TAG
+            -f image-types=$IMAGE_TYPES \
+            -f image-tag=$IMAGE_TAG \
             -f add-latest-tag=$ADD_LATEST_TAG
+
+Deploying Docker Images Remotely
+...............................
+
+This can be done by running the CAS Repository Deploy workflow. This will deploy the docker image to Cloud Run.
+
+This can be done via the github UI from:
+
+https://github.com/cellarium-ai/cellarium-cloud/actions/workflows/deploy-workflow.yml
+
+Or by running with the Github client using the following command:
+
+.. code-block:: bash
+
+    GIT_REF=<branch, git commit, tag, etc.> # Git reference to deploy the image from (helpful if modifying the deploy scripts or configuration files)
+    IMAGE_TAG=<docker tag> # Tag to deploy the docker image from.
+    SERVICE_ACCOUNT=sa-user@<project>.iam.gserviceaccount.com # Service account that will be running the service
+    SECRET_REF=secret-name:latest # Reference to secret in the project's google secret manager as <secret name>:<version or latest> (note that the service account must have access to the secret)
+    DB_CONNECTION=example-project:us-region-example:db-cluster-name # Cloud SQL connection name
+    VPC_CONNECTOR=projects/<project>/locations/<region>/connectors/<connector> # VPC connector to use for the service
+    DEPLOYMENT_PREFIX=example # Prefix to use for the deployment names
+    DEPLOYMENT_FLAVOR=default # Flavor of the deployment to use. Must match a config file in the casp/services/deploy/configs directory
+
+    gh workflow run deploy-workflow.yml repo cellarium-ai/cellarium-cloud \
+            --ref $GIT_REF \
+            -f image-tag=$IMAGE_TAG \
+            -f service-account-email=$SERVICE_ACCOUNT \
+            -f sql-instance=$DB_CONNECTION \
+            -f vpc-connector=$VPC_CONNECTOR \
+            -f config-secret=$SECRET_REF \
+            -f deployment-prefix=$DEPLOYMENT_PREFIX \
+            -f flavor=$DEPLOYMENT_FLAVOR
+
 
 Service Architecture
 ....................

--- a/src/casp/services/admin/README.rst
+++ b/src/casp/services/admin/README.rst
@@ -46,7 +46,10 @@ To deploy the Docker image using Cloud Run run (see `Cloud Run Documentation <ht
     --set-secrets=/app/settings/.env=${SECRET_REF} \
     --command=casp/services/admin/entrypoint.sh \
     --platform managed \
+    --ingress internal \
     --allow-unauthenticated
+
+You can also deploy the services using the deploy-workflow.yml GitHub action.
 
 Accessing the Service
 ---------------------

--- a/src/casp/services/api/README.rst
+++ b/src/casp/services/api/README.rst
@@ -111,6 +111,8 @@ To deploy the Docker image using Cloud Run run (see `Cloud Run Documentation <ht
     --command=python --args="casp/services/api/main.py" \
     --allow-unauthenticated
 
+You can also deploy the services using the deploy-workflow.yml GitHub action.
+
 Test your deployment with:
 
 .. code-block:: bash

--- a/src/casp/services/deploy/cloudrun/README.rst
+++ b/src/casp/services/deploy/cloudrun/README.rst
@@ -1,24 +1,34 @@
-{
-  "cas-admin": {
-    "cpu": "1000m",
-    "memory": "512Mi",
-    "max-instances": 100,
-    "min-instances": 0,
-    "concurrency": 80
+Deployment Flavors
+==================
 
-  },
-  "cas-model": {
-    "cpu": "4000m",
-    "memory": "16Gi",
-    "max-instances": 200,
-    "min-instances": 0,
-    "concurrency": 10
-  },
-  "cas-api": {
-    "cpu": "1000m",
-    "memory": "4Gi",
-    "max-instances": 200,
-    "min-instances": 0,
-    "concurrency": 20
-  }
-}
+This directory should contain various deployment configurations for the sizes of services used by the deployment GitHub action.
+These are JSON files named `[flavor].json` and the contents should look like:
+
+.. code-block:: json
+
+    {
+      "cas-admin": {
+        "cpu": "1000m",
+        "memory": "512Mi",
+        "max-instances": 100,
+        "min-instances": 0,
+        "concurrency": 80
+
+      },
+      "cas-model": {
+        "cpu": "4000m",
+        "memory": "16Gi",
+        "max-instances": 200,
+        "min-instances": 0,
+        "concurrency": 10
+      },
+      "cas-api": {
+        "cpu": "1000m",
+        "memory": "4Gi",
+        "max-instances": 200,
+        "min-instances": 0,
+        "concurrency": 20
+      }
+    }
+
+With the appropriate values for the service.

--- a/src/casp/services/deploy/cloudrun/README.rst
+++ b/src/casp/services/deploy/cloudrun/README.rst
@@ -1,0 +1,24 @@
+{
+  "cas-admin": {
+    "cpu": "1000m",
+    "memory": "512Mi",
+    "max-instances": 100,
+    "min-instances": 0,
+    "concurrency": 80
+
+  },
+  "cas-model": {
+    "cpu": "4000m",
+    "memory": "16Gi",
+    "max-instances": 200,
+    "min-instances": 0,
+    "concurrency": 10
+  },
+  "cas-api": {
+    "cpu": "1000m",
+    "memory": "4Gi",
+    "max-instances": 200,
+    "min-instances": 0,
+    "concurrency": 20
+  }
+}

--- a/src/casp/services/deploy/cloudrun/default.json
+++ b/src/casp/services/deploy/cloudrun/default.json
@@ -1,0 +1,24 @@
+{
+  "cas-admin": {
+    "cpu": "1000m",
+    "memory": "512Mi",
+    "max-instances": 100,
+    "min-instances": 0,
+    "concurrency": 80
+
+  },
+  "cas-model": {
+    "cpu": "4000m",
+    "memory": "16Gi",
+    "max-instances": 200,
+    "min-instances": 0,
+    "concurrency": 10
+  },
+  "cas-api": {
+    "cpu": "1000m",
+    "memory": "4Gi",
+    "max-instances": 200,
+    "min-instances": 0,
+    "concurrency": 20
+  }
+}

--- a/src/casp/services/deploy/cloudrun/large.json
+++ b/src/casp/services/deploy/cloudrun/large.json
@@ -1,0 +1,24 @@
+{
+  "cas-admin": {
+    "cpu": "2000m",
+    "memory": "2Gi",
+    "max-instances": 100,
+    "min-instances": 1,
+    "concurrency": 80
+
+  },
+  "cas-model": {
+    "cpu": "8000m",
+    "memory": "32Gi",
+    "max-instances": 200,
+    "min-instances": 1,
+    "concurrency": 10
+  },
+  "cas-api": {
+    "cpu": "8000m",
+    "memory": "16Gi",
+    "max-instances": 200,
+    "min-instances": 1,
+    "concurrency": 32
+  }
+}

--- a/src/casp/services/logging.py
+++ b/src/casp/services/logging.py
@@ -92,12 +92,21 @@ class StreamHandler(logging.StreamHandler):
                 global_log_fields["logging.googleapis.com/trace"] = trace.get_trace(self.project_id)
                 global_log_fields["logging.googleapis.com/spanId"] = trace.span_id
 
+            locator = {
+                "filename": record.filename,
+                "lineno": record.lineno,
+                "funcname": record.funcName,
+                "module": record.pathname,
+                "process": record.process,
+            }
             # Complete a structured log entry.
             entry = dict(
                 severity=record.levelname,
                 message=message,
                 # Add ability to filter logs on sentry trace id
                 sentry_trace_id=sentry_trace_id,
+                # Add python debugging information
+                locator=locator,
                 **global_log_fields,
             )
 

--- a/src/casp/services/model_inference/README.rst
+++ b/src/casp/services/model_inference/README.rst
@@ -59,7 +59,10 @@ To deploy the Docker image using Cloud Run run (see `Cloud Run Documentation <ht
     --set-secrets=/app/settings/.env=${SECRET_REF} \
     --command python --args "casp/services/model_inference/main.py" \
     --allow-unauthenticated \
+    --ingress internal \
     --platform=managed
+
+You can also deploy the services using the deploy-workflow.yml GitHub action.
 
 Accessing the Service
 ---------------------

--- a/src/casp/services/utils/email_utils.py
+++ b/src/casp/services/utils/email_utils.py
@@ -78,7 +78,7 @@ class EmailSender:
             subject="Welcome to the Cellarium Cell Annotation Service",
             content_path_html="welcome.html",
             content_path_plain="welcome.txt",
-            sub_values={key: key},
+            sub_values={"key": key},
         )
 
     def send_new_key_email(self, email: str, key: str) -> None:
@@ -93,5 +93,5 @@ class EmailSender:
             subject="New Cellarium Cell Annotation Service Key you Requested",
             content_path_html="new_key.html",
             content_path_plain="new_key.txt",
-            sub_values={key: key},
+            sub_values={"key": key},
         )


### PR DESCRIPTION
This PR adds a brand new GitHub workflow + action that will let us deploy the built docker image to CAS services via github.

Once merged, it will be doable from the UI but until then, this can be run via the github CLI using:

```
    GIT_REF=<branch, git commit, tag, etc.> # Git reference to deploy the image from (helpful if modifying the deploy scripts or configuration files)
    IMAGE_TAG=<docker tag> # Tag to deploy the docker image from.
    SERVICE_ACCOUNT=sa-user@<project>.iam.gserviceaccount.com # Service account that will be running the service
    SECRET_REF=secret-name:latest # Reference to secret in the project's google secret manager as <secret name>:<version or latest> (note that the service account must have access to the secret)
    DB_CONNECTION=example-project:us-region-example:db-cluster-name # Cloud SQL connection name
    VPC_CONNECTOR=projects/<project>/locations/<region>/connectors/<connector> # VPC connector to use for the service
    DEPLOYMENT_PREFIX=example # Prefix to use for the deployment names
    DEPLOYMENT_FLAVOR=default # Flavor of the deployment to use. Must match a config file in the casp/services/deploy/configs directory

    gh workflow run deploy-workflow.yml repo cellarium-ai/cellarium-cloud \
            --ref $GIT_REF \
            -f image-tag=$IMAGE_TAG \
            -f service-account-email=$SERVICE_ACCOUNT \
            -f sql-instance=$DB_CONNECTION \
            -f vpc-connector=$VPC_CONNECTOR \
            -f config-secret=$SECRET_REF \
            -f deployment-prefix=$DEPLOYMENT_PREFIX \
            -f flavor=$DEPLOYMENT_FLAVOR
```

This will deploy the 3 CAS services and admin and model will be behind the VPC.

**Note: For this to work: you must remove the `MODEL_SERVER_URL` parameter in the secret you are using to deploy.**

This will deploy services named `<prefix>-[cas-model|cas-admin|cas-api]` with labels that include the prefix and the github user that triggered the deploy:

![image](https://github.com/cellarium-ai/cellarium-cloud/assets/5633787/692b81c4-9bef-44cd-b95d-fc58851e6eee)

The GitHub run will output the URLs to the deployments:
![image](https://github.com/cellarium-ai/cellarium-cloud/assets/5633787/dc0a3e83-543e-459f-a907-7fe92fb854a3)


A couple of other drive-bys that I also did as part of the PR for things that came up while debugging:

- The version of uvicorn is pinned to 0.29.0 to avoid log chatter and a potentially bigger issue with background thread management
- I added a locator field to the stackdriver logs to make it easier to tell where random log messages from from.  It looks like:

![image](https://github.com/cellarium-ai/cellarium-cloud/assets/5633787/f16f1211-054b-4048-9bc3-d27413b68ef8)

