### PR TITLE
CAS-6 Make it possible to gather feedback from users

### DIFF
--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -101,6 +101,7 @@ class AllEnvSettings(BaseSettings):
     # Email settings
     SENDGRID_API_KEY: str = os.environ.get("SENDGRID_API_KEY", "")
     FROM_ADDRESS: str = os.environ.get("FROM_ADDRESS", "cas-support@broadinstitute.org")
+    FEEDBACK_FORM_BASE_URL: str = os.environ.get("FEEDBACK_FORM_BASE_URL")
 
 
 class DevSettings(AllEnvSettings):

--- a/src/casp/services/admin/__init__.py
+++ b/src/casp/services/admin/__init__.py
@@ -6,7 +6,7 @@ from casp.services import db, settings
 flask_app = Flask(__name__)
 flask_app.config.from_object(settings)
 basic_auth = HTTPBasicAuth()
-db_session = db.get_db_session_maker()
+db_session = db.get_db_session_maker()()
 
 
 @basic_auth.verify_password
@@ -21,6 +21,12 @@ def verify_password(username: str, password: str) -> str:
         "password"
     ):
         return username
+
+
+@flask_app.teardown_appcontext
+def shutdown_session(exception=None):
+    # Ensure that the session is closed at the end of each request
+    db_session.close()
 
 
 import casp.services.admin.views  # noqa

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -16,11 +16,9 @@ from flask_admin.model.template import EndpointLinkRowAction, LinkRowAction
 from werkzeug.exceptions import HTTPException
 
 from casp.services import _auth, settings
-from casp.services.admin import basic_auth, flask_app
-from casp.services.db import get_db_session_maker, models, ops
+from casp.services.admin import basic_auth, db_session, flask_app
+from casp.services.db import models, ops
 from casp.services.utils.email_utils import EmailSender
-
-db_session = get_db_session_maker()()
 
 email_sender = EmailSender(sendgrid_key=settings.SENDGRID_API_KEY, from_address=settings.FROM_ADDRESS)
 

--- a/src/casp/services/api/clients/model_client.py
+++ b/src/casp/services/api/clients/model_client.py
@@ -65,6 +65,12 @@ class HTTPAsyncClient:
         # Forward along the user auth if it exists
         if HeaderKeys.authorization in context and context[HeaderKeys.authorization] is not None:
             headers[HeaderKeys.authorization.value] = context[HeaderKeys.authorization]
+        # Forward along the client session id if it exists
+        if HeaderKeys.client_session_id in context and context[HeaderKeys.client_session_id] is not None:
+            headers[HeaderKeys.client_session_id.value] = context[HeaderKeys.client_session_id]
+        # Forward along the client action id if it exists
+        if HeaderKeys.client_action_id in context and context[HeaderKeys.client_action_id] is not None:
+            headers[HeaderKeys.client_action_id.value] = context[HeaderKeys.client_action_id]
 
         async with aiohttp.ClientSession(timeout=timeout) as session:
             try:

--- a/src/casp/services/api/data_manager/cellarium_general.py
+++ b/src/casp/services/api/data_manager/cellarium_general.py
@@ -40,6 +40,18 @@ class CellariumGeneralDataManager(BaseDataManager):
             default_feature_schema=settings.DEFAULT_FEATURE_SCHEMA, application_version=settings.APP_VERSION
         )
 
+    def feedback_opt_out(self, user: models.User) -> None:
+        """
+        Opt out user from feedback requests
+
+        :param user: User object to opt out
+        """
+        user.feedback_opt_out = True
+        with self.system_data_db_session_maker() as session:
+            session.execute(sa.update(models.User).where(models.User.id == user.id).values(ask_for_feedback=False))
+            session.commit()
+            return session.query(models.User).get(user.id)
+
     def get_feature_schemas(self) -> t.List[schemas.FeatureSchemaInfo]:
         """
         :return: List of gene schema objects

--- a/src/casp/services/api/data_manager/cellarium_general.py
+++ b/src/casp/services/api/data_manager/cellarium_general.py
@@ -40,7 +40,7 @@ class CellariumGeneralDataManager(BaseDataManager):
             default_feature_schema=settings.DEFAULT_FEATURE_SCHEMA, application_version=settings.APP_VERSION
         )
 
-    def feedback_opt_out(self, user: models.User) -> None:
+    def feedback_opt_out(self, user: models.User) -> models.User:
         """
         Opt out user from feedback requests
 

--- a/src/casp/services/api/routers/cellarium_general_router.py
+++ b/src/casp/services/api/routers/cellarium_general_router.py
@@ -34,7 +34,6 @@ async def validate_token(user: models.User = Depends(dependencies.authenticate_u
 async def feedback_answer(client_session_id: str, client_action_id: str):
     """
     Redirect to the feedback form with the client session ID
-
     """
     return RedirectResponse(
         settings.FEEDBACK_FORM_BASE_URL.format(client_session_id=client_session_id, client_action_id=client_action_id)

--- a/src/casp/services/api/schemas/cellarium_general.py
+++ b/src/casp/services/api/schemas/cellarium_general.py
@@ -25,6 +25,7 @@ class ApplicationInfo(BaseModel):
 class UserInfo(BaseModel):
     username: str
     email: str
+    should_ask_for_feedback: bool = Field(example=True)
 
 
 class UserQuota(BaseModel):

--- a/src/casp/services/api/services/cellarium_general_service.py
+++ b/src/casp/services/api/services/cellarium_general_service.py
@@ -23,6 +23,14 @@ class CellariumGeneralService:
         """
         return self.cellarium_general_dm.get_application_info()
 
+    def feedback_opt_out(self, user: models.User) -> models.User:
+        """
+        Opt out user from feedback requests
+
+        :param user: User object to opt out
+        """
+        return self.cellarium_general_dm.feedback_opt_out(user=user)
+
     def get_feature_schemas(self) -> t.List[schemas.FeatureSchemaInfo]:
         """
         Get all available feature schemas

--- a/src/casp/services/app.py
+++ b/src/casp/services/app.py
@@ -17,7 +17,7 @@ from casp.services._auth.exceptions import TokenException
 from casp.services.api import exception_handlers
 from casp.services.api.data_manager.exceptions import NotFound
 from casp.services.api.services.exceptions import APIBaseException
-from casp.services.constants import ContextKeys, HeaderKeys
+from casp.services.constants import ContextKeys, HeaderKeys, SentryTags
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,14 @@ class AuthorizationPlugin(Plugin):
     key = HeaderKeys.authorization
 
 
+class ClientSessionPlugin(Plugin):
+    key = HeaderKeys.client_session_id
+
+
+class ClientActionPlugin(Plugin):
+    key = HeaderKeys.client_action_id
+
+
 BASE_PLUGGINS: t.Sequence[Plugin] = (
     # Extracts the user-agent header and makes it available to the request context.
     plugins.UserAgentPlugin(),
@@ -56,6 +64,10 @@ BASE_PLUGGINS: t.Sequence[Plugin] = (
     CloudTraceContextPlugin(),
     # Extracts the authorization header and makes it available to the request context.
     AuthorizationPlugin(),
+    # Extracts the x-client-session-id header and makes it available to the request context.
+    ClientSessionPlugin(),
+    # Extracts the x-client-action-id header and makes it available to the request context.
+    ClientActionPlugin(),
 )
 
 
@@ -81,6 +93,55 @@ class RequestClientMiddleware(BaseHTTPMiddleware):
         context[ContextKeys.client] = request.client
         response = await call_next(request)
         return response
+
+
+class ContextToSentryMiddleware(BaseHTTPMiddleware):
+    """
+    Adds the a value from the request context to the Sentry context.
+    """
+
+    def __init__(self, context_key: HeaderKeys, sentry_tag: SentryTags, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context_key = context_key
+        self.sentry_tag_name = sentry_tag
+
+    async def dispatch(self, request: Request, call_next: DispatchFunction) -> Response:
+        value = None
+        if self.context_key in context:
+            value = context[self.context_key]
+            sentry_sdk.set_tag(self.sentry_tag_name, value)
+        response = await call_next(request)
+        if hasattr(response, "headers") and value is not None:
+            response.headers[self.context_key] = value
+        return response
+
+
+class ClientSessionIdMiddleware(ContextToSentryMiddleware):
+    """
+    Adds the request's session id to the Sentry context.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            context_key=HeaderKeys.client_session_id,
+            sentry_tag=SentryTags.client_session_id,
+            *args,
+            **kwargs,
+        )
+
+
+class ClientActionIdMiddleware(ContextToSentryMiddleware):
+    """
+    Adds the request's session id to the Sentry context.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            context_key=HeaderKeys.client_action_id,
+            sentry_tag=SentryTags.client_action_id,
+            *args,
+            **kwargs,
+        )
 
 
 class SentryResponseDecoratorMiddleware(BaseHTTPMiddleware):
@@ -134,7 +195,7 @@ class CASService(FastAPI):
         self.port = port
 
         # Configure Sentry integration
-        if sentry_application_id is not None:
+        if sentry_application_id is not None and settings.SENTRY_DSN is not None:
             sentry_sdk.init(
                 dsn=settings.SENTRY_DSN,
                 server_name=sentry_application_id,
@@ -152,6 +213,8 @@ class CASService(FastAPI):
             Middleware(RawContextMiddleware, plugins=_plugins),
             Middleware(RequestClientMiddleware),
             Middleware(SentryResponseDecoratorMiddleware),
+            Middleware(ClientSessionIdMiddleware),
+            Middleware(ClientActionIdMiddleware),
         ]
 
         # Perform basic initialization

--- a/src/casp/services/app.py
+++ b/src/casp/services/app.py
@@ -97,7 +97,7 @@ class RequestClientMiddleware(BaseHTTPMiddleware):
 
 class ContextToSentryMiddleware(BaseHTTPMiddleware):
     """
-    Adds the a value from the request context to the Sentry context.
+    Adds the value from the request context to the Sentry context.
     """
 
     def __init__(self, context_key: HeaderKeys, sentry_tag: SentryTags, *args, **kwargs):
@@ -132,7 +132,7 @@ class ClientSessionIdMiddleware(ContextToSentryMiddleware):
 
 class ClientActionIdMiddleware(ContextToSentryMiddleware):
     """
-    Adds the request's session id to the Sentry context.
+    Adds the request's action id to the Sentry context.
     """
 
     def __init__(self, *args, **kwargs):

--- a/src/casp/services/constants.py
+++ b/src/casp/services/constants.py
@@ -39,8 +39,8 @@ class SentryTags(str, Enum):
 
     # The client session id that is used to track a user's CAS client session.
     client_session_id = "client-session-id"
-    # The action id that is used to group calls from a given client intraction together
-    # (e.g. all parallel chunks from an annotation call woud have the action id).
+    # The action id that is used to group calls from a given client interaction together
+    # (e.g. all parallel chunks from an annotation call woud have the same action id).
     client_action_id = "client-action-id"
 
 

--- a/src/casp/services/constants.py
+++ b/src/casp/services/constants.py
@@ -25,6 +25,23 @@ class HeaderKeys(str, Enum):
     authorization = "Authorization"
     # The trace id to return to users as a header.  Can be used for debugging.
     trace_id = "x-trace-id"
+    # The client session id that is used to track a user's CAS client session.
+    client_session_id = "x-client-session-id"
+    # The action id that is used to group calls from a given client intraction together
+    # (e.g. all parallel chunks from an annotation call woud have the action id).
+    client_action_id = "x-client-action-id"
+
+
+class SentryTags(str, Enum):
+    """
+    Tags used in the Sentry context.
+    """
+
+    # The client session id that is used to track a user's CAS client session.
+    client_session_id = "client-session-id"
+    # The action id that is used to group calls from a given client intraction together
+    # (e.g. all parallel chunks from an annotation call woud have the action id).
+    client_action_id = "client-action-id"
 
 
 class LogRecordKeys(str, Enum):

--- a/src/casp/services/db/migrations/versions/t_2024-05-16_09-49-58_user_keys.py
+++ b/src/casp/services/db/migrations/versions/t_2024-05-16_09-49-58_user_keys.py
@@ -1,7 +1,7 @@
 """user keys
 
 Revision ID: 48b338e2e8e0
-Revises: 429a028f2c30
+Revises: 9f6eb1c6a5a0
 Create Date: 2024-05-16 09:49:58.443718
 
 """

--- a/src/casp/services/db/migrations/versions/t_2024-06-04_18-55-57_user_feedback.py
+++ b/src/casp/services/db/migrations/versions/t_2024-06-04_18-55-57_user_feedback.py
@@ -1,0 +1,28 @@
+"""user feedback
+
+Revision ID: dbee57c2946d
+Revises: 48b338e2e8e0
+Create Date: 2024-06-04 18:55:57.551963
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dbee57c2946d"
+down_revision = "48b338e2e8e0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users_user", sa.Column("ask_for_feedback", sa.Boolean(), nullable=True))
+    # Backfill the new column's data with default value (e.g. is_grpc = True)
+    op.execute("update users_user set ask_for_feedback = true")
+    # Change the new column to not nullable
+    op.alter_column("users_user", "ask_for_feedback", existing_type=sa.BOOLEAN(), nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("users_user", "ask_for_feedback")

--- a/src/casp/services/db/models/users.py
+++ b/src/casp/services/db/models/users.py
@@ -53,14 +53,18 @@ sa.inspect(User).add_property(
     key="total_cells_processed",
     prop=column_property(
         User.cells_processed
-        + sa.select(sa.func.sum(UserActivity.cell_count)).where(UserActivity.user_id == User.id).scalar_subquery()
+        + sa.select(sa.func.sum(UserActivity.cell_count))
+        .where((UserActivity.user_id == User.id) & (UserActivity.event == UserActivityEvent.SUCCEEDED))
+        .scalar_subquery()
     ),
 )
 sa.inspect(User).add_property(
     key="total_requests_processed",
     prop=column_property(
         User.requests_processed
-        + sa.select(sa.func.count(UserActivity.id)).where(UserActivity.user_id == User.id).scalar_subquery()
+        + sa.select(sa.func.count(UserActivity.id))
+        .where((UserActivity.user_id == User.id) & (UserActivity.event == UserActivityEvent.SUCCEEDED))
+        .scalar_subquery()
     ),
 )
 

--- a/src/casp/services/db/models/users.py
+++ b/src/casp/services/db/models/users.py
@@ -21,6 +21,7 @@ class User(db.Base):
     is_admin = sa.Column(sa.Boolean(), default=True, nullable=False)
     cell_quota = sa.Column(sa.Integer(), default=50000, nullable=False)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.now(datetime.timezone.utc))
+    ask_for_feedback = sa.Column(sa.Boolean(), default=True, nullable=False)
 
     __tablename__ = "users_user"
 
@@ -52,18 +53,14 @@ sa.inspect(User).add_property(
     key="total_cells_processed",
     prop=column_property(
         User.cells_processed
-        + sa.select(sa.func.sum(UserActivity.cell_count))
-        .where((UserActivity.user_id == User.id) & (UserActivity.event == UserActivityEvent.SUCCEEDED))
-        .scalar_subquery()
+        + sa.select(sa.func.sum(UserActivity.cell_count)).where(UserActivity.user_id == User.id).scalar_subquery()
     ),
 )
 sa.inspect(User).add_property(
     key="total_requests_processed",
     prop=column_property(
         User.requests_processed
-        + sa.select(sa.func.count(UserActivity.id))
-        .where((UserActivity.user_id == User.id) & (UserActivity.event == UserActivityEvent.SUCCEEDED))
-        .scalar_subquery()
+        + sa.select(sa.func.count(UserActivity.id)).where(UserActivity.user_id == User.id).scalar_subquery()
     ),
 )
 

--- a/src/casp/services/deploy/cloudrun/default.json
+++ b/src/casp/services/deploy/cloudrun/default.json
@@ -3,7 +3,7 @@
     "cpu": "1000m",
     "memory": "512Mi",
     "max-instances": 100,
-    "min-instances": 0,
+    "min-instances": 1,
     "concurrency": 80
 
   },
@@ -11,14 +11,14 @@
     "cpu": "4000m",
     "memory": "16Gi",
     "max-instances": 200,
-    "min-instances": 0,
+    "min-instances": 1,
     "concurrency": 10
   },
   "cas-api": {
     "cpu": "1000m",
     "memory": "4Gi",
     "max-instances": 200,
-    "min-instances": 0,
+    "min-instances": 1,
     "concurrency": 20
   }
 }

--- a/src/casp/services/deploy/cloudrun/default.json
+++ b/src/casp/services/deploy/cloudrun/default.json
@@ -3,7 +3,7 @@
     "cpu": "1000m",
     "memory": "512Mi",
     "max-instances": 100,
-    "min-instances": 1,
+    "min-instances": 0,
     "concurrency": 80
 
   },
@@ -11,14 +11,14 @@
     "cpu": "4000m",
     "memory": "16Gi",
     "max-instances": 200,
-    "min-instances": 1,
+    "min-instances": 0,
     "concurrency": 10
   },
   "cas-api": {
     "cpu": "1000m",
     "memory": "4Gi",
     "max-instances": 200,
-    "min-instances": 1,
+    "min-instances": 0,
     "concurrency": 20
   }
 }

--- a/src/casp/services/logging.py
+++ b/src/casp/services/logging.py
@@ -160,7 +160,7 @@ class CustomAccessFormatter(uvicorn.logging.AccessFormatter):
     def formatMessage(self, record: logging.LogRecord) -> str:
         recordcopy = copy(record)
         # Add user, user_id and user_email to the log record if they are present in the context.
-        user_obj = context.data[ContextKeys] if ContextKeys in context.data else None
+        user_obj = context.data[ContextKeys.user] if ContextKeys.user in context.data else None
         if user_obj:
             user_id = user_obj.id
             user_email = user_obj.email

--- a/src/casp/services/logging.py
+++ b/src/casp/services/logging.py
@@ -78,10 +78,14 @@ class StreamHandler(logging.StreamHandler):
             # Add log correlation to nest all log messages.
             # This is only relevant in HTTP-based contexts, and is ignored elsewhere.
             sentry_trace_id = None
+            client_session_id = None
+            client_action_id = None
             try:
                 google_trace_header = context.get(HeaderKeys.cloud_trace_context)
                 if ContextKeys.sentry_trace_id in context.data:
                     sentry_trace_id = context.data[ContextKeys.sentry_trace_id]
+                    client_session_id = context.data[HeaderKeys.client_session_id]
+                    client_action_id = context.data[HeaderKeys.client_action_id]
 
             except ContextDoesNotExistError:
                 # Logging outside of a request context.
@@ -105,6 +109,10 @@ class StreamHandler(logging.StreamHandler):
                 message=message,
                 # Add ability to filter logs on sentry trace id
                 sentry_trace_id=sentry_trace_id,
+                # Add ability to filter logs on session id
+                client_session_id=client_session_id,
+                # Add ability to filter logs on action id
+                client_action_id=client_action_id,
                 # Add python debugging information
                 locator=locator,
                 **global_log_fields,


### PR DESCRIPTION
In service of collecting feedback from users:
- Adds support for passing `x-client-session-id` (separate PR coming for the client repo) from the client to group operations together on the back end for support/feedback ability which will track the overall client session
- Adds support for passing the `x-client-action-id` (separate PR coming for the client repo) from the client to group operations together on the back end for support/feedback ability which will track requests for a given action
- Add support for going to a feedback form:
    - users will hit the `/feedback/answer?client_session_id&client_action_id` endpoint which will redirect to a form url with the client_session_id and client_action_id to track the user
- Add support for opting out of us asking for feedback
- Drive by: small fix to the access logger to properly read the user info from the context
- Drive by: fix our connection pool for the admin utility to just come from one place