### PR TITLE
Fix: DB multiple head revision

### DIFF
--- a/src/casp/services/db/migrations/versions/t_2024-05-16_09-49-58_user_keys.py
+++ b/src/casp/services/db/migrations/versions/t_2024-05-16_09-49-58_user_keys.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "48b338e2e8e0"
-down_revision = "429a028f2c30"
+down_revision = "9f6eb1c6a5a0"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
After merging our previous PRs, our migrations had two "heads," which was caused by having the same reference in 2 latest migrations, preventing automatic migration application. This PR fixes it.