### PR TITLE
Feat: #129 Make index_deployed_id optional

### DIFF
--- a/src/casp/services/db/migrations/versions/t_2024-06-18_13-18-48_make_deployed_index_id_nullable.py
+++ b/src/casp/services/db/migrations/versions/t_2024-06-18_13-18-48_make_deployed_index_id_nullable.py
@@ -1,0 +1,28 @@
+"""Make deployed_index_id nullable
+
+Revision ID: 0045d3785268
+Revises: dbee57c2946d
+Create Date: 2024-06-18 13:18:48.605205
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0045d3785268"
+down_revision = "dbee57c2946d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "ml_management_matchingengineindex", "deployed_index_id", existing_type=sa.VARCHAR(length=255), nullable=True
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "ml_management_matchingengineindex", "deployed_index_id", existing_type=sa.VARCHAR(length=255), nullable=False
+    )

--- a/src/casp/services/db/models/ml_management.py
+++ b/src/casp/services/db/models/ml_management.py
@@ -28,7 +28,7 @@ class CASMatchingEngineIndex(db.Base):
     index_name = sa.Column(sa.String(255), unique=True, nullable=False)
     embedding_dimension = sa.Column(sa.Integer, nullable=False)
     endpoint_id = sa.Column(sa.String(255), unique=False, nullable=False)
-    deployed_index_id = sa.Column(sa.String(255), unique=True, nullable=False)
+    deployed_index_id = sa.Column(sa.String(255), unique=True, nullable=True)
     num_neighbors = sa.Column(sa.Integer, nullable=False)
     model_id = sa.Column(sa.Integer, sa.ForeignKey(f"{CASModel.__tablename__}.id"), nullable=False)
     model = relationship("CASModel", backref=backref("cas_matching_engine", uselist=False))


### PR DESCRIPTION
We need to store undeployed indexes to keep the costs lower, but we still want them to be stored in the database for benchmarking.