### PR TITLE
CAS-36 Remove token from admin page

### DIFF
--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -228,10 +228,6 @@ class UserAdminView(CellariumCloudAdminModelView):
                     try:
                         key = self.key_cache[user_key.key_locator]
                         del self.key_cache[user_key.key_locator]
-                        flash(
-                            gettext(f"A key was created for {model.username}: [{key}].  It will not be shown again"),
-                            "key",
-                        )
                         email_sender.send_new_key_email(email=model.email, key=key)
                     except Exception:
                         logger.error("Error notifying user", exc_info=True)


### PR DESCRIPTION
Pretty simple PR.  Just removes the bit of code that flashes the user's key on creation. Leaving most of the css etc. since we may want to revive it at some point for self-service key creation