### PR TITLE
Created a workflow for spinning up a test server and running integration tests against it

### DIFF
--- a/.github/actions/docker-deploy/action.yml
+++ b/.github/actions/docker-deploy/action.yml
@@ -181,3 +181,11 @@ runs:
           echo "MODEL_SERVER_URL=${{ steps.deploy.outputs.url }}" >> $GITHUB_ENV
         fi
       shell: bash
+
+    - id: set-api-url
+      name: We need to stash the URL for the api server in case it's needed by other jobs
+      run: |
+        if [[ "${{ inputs.deployment-type }}" == "cas-api" ]]; then
+          echo "API_SERVER_URL=${{ steps.deploy.outputs.url }}" >> $GITHUB_ENV
+        fi
+      shell: bash

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -1,0 +1,42 @@
+name: Run cellarium-cas integration tests
+description: Runs the integration tests from the cellarium-cas repository
+inputs:
+  revision:
+    description: The revision of the cellarium-cas repository to use
+    required: false
+    default: main
+  api-key:
+    description: The API key for connecting to the CAS API
+    required: true
+  api-url:
+    description: The URL of the CAS API service
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: checkout
+      name: Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: "cellarium-ai/cellarium-cas"
+        ref: ${{ inputs.revision }}
+        path: "./cellarium-cas"
+    
+    - id: install-dependencies
+      name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements/dev.txt
+      shell: bash
+      working-directory: ./cellarium-cas
+    
+    - id: run-tests
+      name: Run tests
+      env:
+        TEST_API_TOKEN: ${{ inputs.api-key }}
+        TEST_API_URL: ${{ inputs.api-url }}
+      run: |
+        tox -e integration 
+      shell: bash
+      working-directory: ./cellarium-cas

--- a/.github/actions/vector-search-index-deploy/action.yml
+++ b/.github/actions/vector-search-index-deploy/action.yml
@@ -1,0 +1,74 @@
+name: Deploy vector search index
+description: Creates a deployment of the specified vector search index
+inputs:
+  gcp-provider-id:
+    required: true
+    description: CAS GCP Provider ID
+  gcp-service-account-email:
+    required: true
+    description: CAS Deployer Service Account email
+  index-endpoint-id:
+    required: true
+    description: The ID of the vector search index endpoint
+  deployed-index-id:
+    required: true
+    description: An ID string to identify the deployed index
+  deployed-index-endpoint-name:
+    required: true
+    description: Display name of the deployed index endpoint
+  index-id:
+    required: true
+    description: The ID of the vector search index
+  deployment-region:
+    required: false
+    description: The region to which to deploy the index endpoint
+    default: us-central1
+  deployment-project:
+    required: true
+    description: The project to which the index belongs
+runs:
+  using: "composite"
+  steps:
+    - id: checkout
+      name: Checkout
+      uses: actions/checkout@v4
+
+    - id: google-login
+      name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ inputs.gcp-provider-id }}
+        service_account: ${{ inputs.gcp-service-account-email }}
+        access_token_lifetime: 1500s
+
+    - id: deploy-index
+      name: Deploy vector search index
+      shell: bash
+      run: |
+        set -e
+
+        DEPLOYMENT_OP=$(gcloud ai index-endpoints deploy-index ${{ inputs.index-endpoint-id }} \
+          --deployed-index-id=${{ inputs.deployed-index-id }} \
+          --display-name=${{ inputs.deployed-index-endpoint-name }} \
+          --index=${{ inputs.index-id }} \
+          --region=${{ inputs.deployment-region }} \
+          --project=${{ inputs.deployment-project }} \
+          --format="value(name)")
+
+        DEPLOYMENT_OP_ID=$(basename $DEPLOYMENT_OP)
+
+        DEPLOYMENT_DONE=false
+
+        while [ "$DEPLOYMENT_DONE" = false ]; do
+          DEPLOYMENT_DONE_VAL=$(gcloud ai operations describe $DEPLOYMENT_OP_ID \
+            --region=${{ inputs.deployment-region }} \
+            --format="value(done)")
+          if [ "$DEPLOYMENT_DONE_VAL" = "True" ]; then
+            DEPLOYMENT_DONE=true
+            echo "Deployment done?: $DEPLOYMENT_DONE"
+          else
+            echo "Deployment done?: $DEPLOYMENT_DONE"
+            sleep 60
+          fi
+        done

--- a/.github/actions/vector-search-index-undeploy/action.yml
+++ b/.github/actions/vector-search-index-undeploy/action.yml
@@ -1,0 +1,46 @@
+name: Undeploy vector search index
+description: Undeploys the specified vector search index deployment
+inputs:
+  gcp-provider-id:
+    required: true
+    description: CAS GCP Provider ID
+  gcp-service-account-email:
+    required: true
+    description: CAS Deployer Service Account email
+  index-endpoint-id:
+    required: true
+    description: The ID of the vector search index endpoint
+  deployed-index-id:
+    required: true
+    description: An ID string to identify the deployed index
+  deployment-region:
+    required: true
+    description: The region to which the index endpoint is deployed
+    default: us-central1
+  deployment-project:
+    required: true
+    description: The project to which the index belongs
+runs:
+  using: "composite"
+  steps:
+    - id: checkout
+      name: Checkout
+      uses: actions/checkout@v4
+
+    - id: google-login
+      name: Authenticate with Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: ${{ inputs.gcp-provider-id }}
+        service_account: ${{ inputs.gcp-service-account-email }}
+        access_token_lifetime: 1500s
+
+    - id: undeploy-index
+      name: Undeploy vector search index
+      shell: bash
+      run: |
+        gcloud ai index-endpoints undeploy-index ${{ inputs.index-endpoint-id }} \
+        --deployed-index-id=${{ inputs.deployed-index-id }} \
+        --region=${{ inputs.deployment-region }} \
+        --project=${{ inputs.deployment-project }}

--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -1,0 +1,156 @@
+name: CAS Repository Integration Test Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      cellarium-cloud-image-tag:
+        description: 'Docker image tag for the Cellarium Cloud image. Will use the short hash of the last commit in the branch if nothing is passed in.'
+        required: false
+        default: ''
+      cellarium-cas-revision:
+        description: 'Tag or commit hash for the version of the client repo we want to run tests for.  Defaults to latest commit in main if not specified.'
+        required: false
+        default: ''
+      service-account-email:
+        description: 'Service account email used as the identity for the deployment of the Cellarium Cloud test images.'
+        required: true
+        default: ''
+      sql-instance:
+        description: 'The SQL instance to connect to in the form [project]:[region]:[instance]'
+        required: true
+        default: ''
+      vpc-connector:
+        description: 'The VPC connector to use for the test deployment in the form projects/[project]/locations/[region]/connectors/[connector]'
+        required: true
+        default: ''
+      config-secret:
+        description: 'The Google secret to use for the test deployment configuration in the form [secret-name]:[version (or "latest")]'
+        required: true
+        default: ''
+      region:
+        description: 'The region to deploy the test image to'
+        required: false
+        default: 'us-central1'
+      deploy-index:
+        description: 'Whether to deploy and undeploy the vector search index'
+        required: false
+        default: 'false'
+      index-endpoint-id:
+        required: false
+        description: The ID of the vector search index endpoint
+      index-id:
+        required: false
+        description: The ID of the vector search index
+
+jobs:
+  run-integration-tests:
+    name: Set up and run integration tests
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+    
+    env:
+      DOCKER_REGISTRY_NAME: us-central1-docker.pkg.dev
+      PYTORCH_IMAGE_NAME: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/cas-services-cicd/cas-pytorch
+    
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v4
+
+      - id: get-image-tag
+        name: Get tag
+        run: |
+          if [[ "${{ inputs.cellarium-cloud-image-tag }}" == "" ]]; then
+            echo "IMAGE_TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=${{ inputs.cellarium-cloud-image-tag }}" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      - id: build-image
+        name: Build CAS cloud image
+        uses: ./.github/actions/docker-build
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          image-type: 'standard'
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          add-latest-tag: false
+      
+      - id: deploy-model
+        name: Deploy the CAS Model Inference Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-model
+          deployment-prefix: integration-test
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: default
+
+      - id: deploy-api
+        name: Deploy the CAS API Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-api
+          deployment-prefix: integration-test
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: default
+      
+      - id: deploy-index
+        name: Deploy vector search index
+        if: ${{ inputs.deploy-index == 'true' }}
+        uses: ./.github/actions/vector-search-index-deploy
+        with:
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          index-endpoint-id: ${{ inputs.index-endpoint-id }}
+          deployed-index-id: integration_test_deployed_index
+          deployed-index-endpoint-name: integration_test_deployed_index
+          index-id: ${{ inputs.index-id }}
+          deployment-region: ${{ inputs.region }}
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+
+      - id: run-tests
+        name: Run tests
+        uses: ./.github/actions/integration-tests
+        with:
+          revision: ${{ inputs.cellarium-cas-revision }}
+          api-key: ${{ secrets.TEST_API_KEY }}
+          api-url: ${{ env.API_SERVER_URL }}
+
+      - id: undeploy-index
+        name: Undeploy vector search index
+        if: ${{ inputs.deploy-index == 'true' }} && (success() || failure())
+        uses: ./.github/actions/vector-search-index-undeploy
+        with:
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          index-endpoint-id: ${{ inputs.index-endpoint-id }}
+          deployed-index-id: integration_test_deployed_index
+          deployed-region: ${{ inputs.region }}
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+      
+          


### PR DESCRIPTION
Quick summary of the process:

1. Builds the docker image for cellarium-cloud for the specified version
2. Deploys the model service
3. Deploys the API service
4. If user set `deploy-index` to `true`, deploys the specified vector search index
5. Checks out the specified version of cellarium-cas and runs integration tests (currently just the one that was already there)
6. If user set `deploy-index` to `true`, undeploys the specified vector search index

A couple points that warrant further discussion for this PR:

1. When you run the gcloud commands to deploy/undeploy an index, it kicks off the operation and returns immediately.  For the deploy operation, it gives you an operation ID that I am checking repeatedly so it stays on that step until the deploy is complete.  However, undeploy doesn't work this way.  It doesn't return an operation ID, and I can't find a way to look one up.  For now, I don't have any wait logic for undeploy because I figure it's not strictly necessary for the action to complete successfully.  If we think it's necessary, I can maybe do something with reading the log messages from repeated attempts to undeploy, since there are different ones for "that index is currently being undeployed" and "that index is not deployed".
2. Because of the limit on Github Actions workflow inputs, I'm currently hardcoding the ID and display name of the deployed index to `integration_test_deployed_index`.  Theoretically, this is fine as long as you don't have an existing deployed index with that name or ID.  I'm not sure if we want to go another route like providing a config json to allow specifying those things on run.  However, this ties in to another possible complication / discussion point
3. The index you deploy isn't going to be dynamically set to be the one that we test against.  The info for that deployed index needs to already exist in the test DB.  You're basically just inputting the values that match your default index in the test DB.  We could theoretically make it work dynamically if we deployed the index and then wrote its info to the specified test DB, but that does add a level of complexity to this workflow that maybe wouldn't really justify itself with added value.  I'm undecided.