### PR TITLE
Feat: Update cell related models

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ matplotlib
 pandas
 google-cloud-run==0.7.1
 scikit-learn
-cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git@0.0.7
+cellarium-ml==0.0.7
 lightning==2.2.0
 db-dtypes==1.1.1
 Mako==1.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ matplotlib
 pandas
 google-cloud-run==0.7.1
 scikit-learn
-cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git@0.0.4+module
+cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git@0.0.7
 lightning==2.2.0
 db-dtypes==1.1.1
 Mako==1.2.4

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -350,12 +350,12 @@ class CASMatchingEngineAdminView(CellariumCloudAdminModelView):
 
 def shorten_value_formatter(view, context, model, name) -> str:
     """
-    Shorten the value to 20 characters plus ellipsis or return `NULL` if None
+    Shorten the value to 20 characters plus ellipsis or return empty string if None
     """
     value = getattr(model, name)
 
     if value is None:
-        return "NULL"
+        return ""
 
     return value[:20] + "..." if len(value) > 20 else value
 

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -350,9 +350,13 @@ class CASMatchingEngineAdminView(CellariumCloudAdminModelView):
 
 def shorten_value_formatter(view, context, model, name) -> str:
     """
-    Shorten the value to 20 characters plus ellipsis
+    Shorten the value to 20 characters plus ellipsis or return `NULL` if None
     """
     value = getattr(model, name)
+
+    if value is None:
+        return "NULL"
+
     return value[:20] + "..." if len(value) > 20 else value
 
 

--- a/src/casp/services/api/services/consensus_engine/strategies.py
+++ b/src/casp/services/api/services/consensus_engine/strategies.py
@@ -179,18 +179,18 @@ class CellTypeOntologyAwareConsensusStrategy(ConsensusStrategyProtocol):
             total_weight += weight
             total_neighbors += 1
 
-            # Add weight to the neighbor's ontology ID
-            scores_dict[neighbor_cell_type_ontology_id] += weight
-
             try:
-                ancestor_ontology_ids = self.cell_ontology_resource.ancestors_dictionary[neighbor_cell_type_ontology_id]
+                # Add weight to the neighbor's ontology ID
+                scores_dict[neighbor_cell_type_ontology_id] += weight
             except KeyError:
                 total_neighbors_unrecognized += 1
                 continue
+            else:
+                ancestor_ontology_ids = self.cell_ontology_resource.ancestors_dictionary[neighbor_cell_type_ontology_id]
 
-            # Propagate the weight to all ancestors (consistent subgraph of the cell type ontology)
-            for ancestor in ancestor_ontology_ids:
-                scores_dict[ancestor] += weight
+                # Propagate the weight to all ancestors (consistent subgraph of the cell type ontology)
+                for ancestor in ancestor_ontology_ids:
+                    scores_dict[ancestor] += weight
 
         # Normalize the weights
         scores_dict = {k: v / total_weight for k, v in scores_dict.items()}

--- a/src/casp/services/db/migrations/versions/t_2024-06-27_21-00-54_update_cell_related_models_before_new_.py
+++ b/src/casp/services/db/migrations/versions/t_2024-06-27_21-00-54_update_cell_related_models_before_new_.py
@@ -1,0 +1,34 @@
+"""Update cell related models before new ingest
+
+Revision ID: 51a4ad2bb22d
+Revises: 0045d3785268
+Create Date: 2024-06-27 21:00:54.062701
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "51a4ad2bb22d"
+down_revision = "0045d3785268"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("cells_cellinfo", "original_cell_id", existing_type=sa.VARCHAR(length=255), nullable=True)
+    op.alter_column(
+        "cells_cellinfo", "obs_metadata_extra", existing_type=postgresql.JSONB(astext_type=sa.Text()), nullable=True
+    )
+    op.add_column("cells_ingestinfo", sa.Column("dataset_version_id", sa.String(length=255), nullable=True))
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    op.drop_column("cells_ingestinfo", "dataset_version_id")
+    op.alter_column(
+        "cells_cellinfo", "obs_metadata_extra", existing_type=postgresql.JSONB(astext_type=sa.Text()), nullable=False
+    )
+    op.alter_column("cells_cellinfo", "original_cell_id", existing_type=sa.VARCHAR(length=255), nullable=False)

--- a/src/casp/services/db/migrations/versions/t_2024-06-27_21-00-54_update_cell_related_models_before_new_.py
+++ b/src/casp/services/db/migrations/versions/t_2024-06-27_21-00-54_update_cell_related_models_before_new_.py
@@ -1,7 +1,7 @@
 """Update cell related models before new ingest
 
 Revision ID: 51a4ad2bb22d
-Revises: 0045d3785268
+Revises: 05b03bfc2e69
 Create Date: 2024-06-27 21:00:54.062701
 
 """
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "51a4ad2bb22d"
-down_revision = "0045d3785268"
+down_revision = "05b03bfc2e69"
 branch_labels = None
 depends_on = None
 
@@ -23,7 +23,6 @@ def upgrade() -> None:
         "cells_cellinfo", "obs_metadata_extra", existing_type=postgresql.JSONB(astext_type=sa.Text()), nullable=True
     )
     op.add_column("cells_ingestinfo", sa.Column("dataset_version_id", sa.String(length=255), nullable=True))
-    # ### end Alembic commands ###
 
 
 def downgrade() -> None:

--- a/src/casp/services/db/models/cells.py
+++ b/src/casp/services/db/models/cells.py
@@ -10,6 +10,7 @@ from casp.services import db
 class CellIngestInfo(db.Base):
     cas_ingest_id = sa.Column(sa.String(255), unique=True, nullable=False, primary_key=True)
     dataset_id = sa.Column(sa.String(255), nullable=False)
+    dataset_version_id = sa.Column(sa.String(255), nullable=True)
     uns_metadata = sa.Column(JSONB, nullable=False, default={})
     ingest_timestamp = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
 
@@ -44,8 +45,8 @@ class CellInfo(db.Base):
         sa.String(255), sa.ForeignKey(f"{CellIngestInfo.__tablename__}.cas_ingest_id"), nullable=False, index=True
     )
     cas_ingest = relationship("CellIngestInfo", backref=backref("cell_info", uselist=False))
-    original_cell_id = sa.Column(sa.String(255), nullable=False)
-    obs_metadata_extra = sa.Column(JSONB, nullable=False, default={})
+    original_cell_id = sa.Column(sa.String(255), nullable=True)
+    obs_metadata_extra = sa.Column(JSONB, nullable=True, default={})
     is_primary_data = sa.Column(sa.Boolean(), default=True, nullable=True, index=True)
     donor_id = sa.Column(sa.String(255), nullable=True)
     # Cell Features

--- a/src/casp/services/model_inference/services.py
+++ b/src/casp/services/model_inference/services.py
@@ -61,8 +61,8 @@ class ModelInferenceService:
         cellarium_data_module = CellariumAnnDataDataModule.load_from_checkpoint(
             cellarium_checkpoint_file, dadc=adata, batch_size=adata.n_obs, num_workers=0
         )
-        cellarium_data_module.setup()
-        batch = next(iter(cellarium_data_module.train_dataloader()))
+        cellarium_data_module.setup(stage="predict")
+        batch = next(iter(cellarium_data_module.predict_dataloader()))
 
         cellarium_output_dict = cellarium_module(batch)
 


### PR DESCRIPTION
Updates:
* Add dataset_version_id to ingest info table
* Drop not null constraints from `obs_metadata_extra` and `original_cell_id` as for the current extract they are not necessary.
* Since in new data we now have "unknown" cell type instead of "naive cell" we have to handle this in ontology aware strategy