### PR TITLE
CAS-43 Bump the version of the cloud sql connector

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -81,6 +81,25 @@ jobs:
           gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
           add-latest-tag: false
       
+      - id: deploy-admin
+        name: Deploy the CAS Admin Service
+        uses: ./.github/actions/docker-deploy
+        with:
+          docker-registry-name: ${{ env.DOCKER_REGISTRY_NAME }}
+          image-name: ${{ env.PYTORCH_IMAGE_NAME }}
+          image-tag: ${{ env.IMAGE_TAG }}
+          gcp-provider-id: ${{ secrets.GCP_PROVIDER_ID }}
+          gcp-service-account-email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          deployment-type: cas-admin
+          deployment-prefix: integration-test
+          deployment-project: ${{ secrets.GCP_PROJECT_ID }}
+          deployment-service-account-email: ${{ inputs.service-account-email }}
+          deployment-sql-instance: ${{ inputs.sql-instance }}
+          deployment-vpc-connector: ${{ inputs.vpc-connector }}
+          deployment-config-secret: ${{ inputs.config-secret }}
+          deployment-region: ${{ inputs.region }}
+          deployment-flavor: default
+
       - id: deploy-model
         name: Deploy the CAS Model Inference Service
         uses: ./.github/actions/docker-deploy

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ Flask-HTTPAuth==4.7.0
 PyJWT==2.6.0
 alembic==1.9.2
 gunicorn==20.1.0
-pg8000==1.29.4
+pg8000==1.31.2
 cloud-sql-python-connector==1.10.0
 neptune==1.1.1
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ cellarium-ml @ git+https://github.com/cellarium-ai/cellarium-ml.git@0.0.4+module
 lightning==2.2.0
 db-dtypes==1.1.1
 Mako==1.2.4
-smart-open==6.4.0
+smart-open==7.0.4
 sqlparse==0.4.4
 Werkzeug==2.2.2
 sentry-sdk==1.39.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ PyJWT==2.6.0
 alembic==1.9.2
 gunicorn==20.1.0
 pg8000==1.29.4
-cloud-sql-python-connector==1.1.0
+cloud-sql-python-connector==1.10.0
 neptune==1.1.1
 matplotlib
 pandas

--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -102,6 +102,7 @@ class AllEnvSettings(BaseSettings):
     SENDGRID_API_KEY: str = os.environ.get("SENDGRID_API_KEY", "")
     FROM_ADDRESS: str = os.environ.get("FROM_ADDRESS", "cas-support@broadinstitute.org")
     FEEDBACK_FORM_BASE_URL: str = os.environ.get("FEEDBACK_FORM_BASE_URL")
+    DB_LOG_QUERIES: bool = os.environ.get("DB_LOG_QUERIES", False)
 
 
 class DevSettings(AllEnvSettings):

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -31,6 +31,7 @@ def create_engine() -> sqlalchemy.engine.base.Engine:
             max_overflow=settings.DB_CONNECTION_POOL_MAX_OVERFLOW,
             pool_timeout=settings.DB_CONNECTION_POOL_TIMEOUT,
             pool_recycle=settings.DB_CONNECTION_POOL_RECYCLE,
+            echo=settings.DB_LOG_QUERIES,
         )
 
     else:

--- a/src/casp/services/deploy/Dockerfile.ns.pytorch
+++ b/src/casp/services/deploy/Dockerfile.ns.pytorch
@@ -1,4 +1,4 @@
-FROM anibali/pytorch:2.0.0-nocuda
+FROM anibali/pytorch:2.0.1-nocuda
 
 WORKDIR /app
 USER root

--- a/src/casp/services/deploy/Dockerfile.ns.pytorch_cuda
+++ b/src/casp/services/deploy/Dockerfile.ns.pytorch_cuda
@@ -1,4 +1,4 @@
-FROM anibali/pytorch:2.0.0-cuda11.8
+FROM anibali/pytorch:2.0.1-cuda11.8
 
 WORKDIR /app
 USER root

--- a/src/casp/services/deploy/Dockerfile.pytorch
+++ b/src/casp/services/deploy/Dockerfile.pytorch
@@ -1,4 +1,4 @@
-FROM anibali/pytorch:2.0.0-nocuda
+FROM anibali/pytorch:2.0.1-nocuda
 
 WORKDIR /app
 USER root

--- a/src/casp/services/deploy/Dockerfile.pytorch_cuda
+++ b/src/casp/services/deploy/Dockerfile.pytorch_cuda
@@ -1,4 +1,4 @@
-FROM anibali/pytorch:2.0.0-cuda11.8
+FROM anibali/pytorch:2.0.1-cuda11.8
 
 WORKDIR /app
 USER root


### PR DESCRIPTION
...also make it so we could log queries in prod if we have to

*Note*: this required upgrading a fair number of components:
- pg8000 (to support socket connections)
- The pytorch image to 2.0.1
- Python to 3.11.4 (via the pytorch image)
- smart-open (seemed to be causing issues initializing)

I also needed to make the initialization of the db session maker to the first connection attempt since it requires google creds and we don't want to require that for unit tests.

Also Note:
I ran the integration tests to verify (woo!) but did have to change to make it deploy the admin service so that the DB would migrate (that caused a failure initially).  Some day we should decouple that but not today.