### PR TITLE
CAS-44 Update default email sender and update email with correct pip install

### DIFF
--- a/src/casp/services/_settings.py
+++ b/src/casp/services/_settings.py
@@ -100,7 +100,7 @@ class AllEnvSettings(BaseSettings):
     DEBUG: bool = False
     # Email settings
     SENDGRID_API_KEY: str = os.environ.get("SENDGRID_API_KEY", "")
-    FROM_ADDRESS: str = os.environ.get("FROM_ADDRESS", "cas-support@broadinstitute.org")
+    FROM_ADDRESS: str = os.environ.get("FROM_ADDRESS", "Cellarium CAS <no-reply@cellarium.ai>")
     FEEDBACK_FORM_BASE_URL: str = os.environ.get("FEEDBACK_FORM_BASE_URL")
     DB_LOG_QUERIES: bool = os.environ.get("DB_LOG_QUERIES", False)
 

--- a/src/casp/services/admin/templates/email/new_key.html
+++ b/src/casp/services/admin/templates/email/new_key.html
@@ -8,4 +8,4 @@
 
 <p>Please keep this key secure and do not share it with others.</p>
 
-<p>For questions or if you did not request this key, please email the Cell Annotation team at cas-support@broadinstitute.org.</p>
+<p>For questions or if you did not request this key, please email the Cell Annotation team at <a href="mailto:cas-support@broadinstitute.org">cas-support@broadinstitute.org</a>.</p>

--- a/src/casp/services/admin/templates/email/welcome.html
+++ b/src/casp/services/admin/templates/email/welcome.html
@@ -9,7 +9,7 @@
 
   <p>Please keep this key secure and do not share it with others.</p>
 
-  <p>For questions or if you did not request this key, please email the Cell Annotation Service team at <a href="mailto:cas-support@broadinstitute.org">cas-support@broadinstitute.org</a></a>.</p>
+  <p>For questions or if you did not request this key, please email the Cell Annotation Service team at <a href="mailto:cas-support@broadinstitute.org">cas-support@broadinstitute.org</a>.</p>
 
   <table style="border-collapse: collapse">
     <tr>
@@ -26,7 +26,7 @@
     <tr>
       <td style="padding:0" colspan="2">
         <div style="background:#f8e9fd;padding:10px;margin:10px 0;width:700px;font-family:monospace">
-        $ pip install git+https://github.com/broadinstitute/cell-annotation-service-client.git
+        $ pip install cellarium-cas
         </div>
       </td>
     </tr> 

--- a/src/casp/services/admin/templates/email/welcome.txt
+++ b/src/casp/services/admin/templates/email/welcome.txt
@@ -11,7 +11,7 @@ For questions or if you did not request this key, please email the Cell Annotati
 Documentation can be found at:	https://cellarium-cas.readthedocs.io/en/latest
 Sample code can be found at:	  https://github.com/cellarium-ai/cellarium-cas/blob/main/README.md
 Python client can be installed via pip:
-$ pip install git+https://github.com/broadinstitute/cell-annotation-service-client.git
+$ pip install cellarium-cas
 
 Please do not hesitate to reach out with any questions or feedback!
 


### PR DESCRIPTION
What it says on the tin.  I updated the config in prod but I wanted to have the default reflect the working value.  Also updates the pip install to not install from github