### PR TITLE
CAS-58 Fix Sentry Error Spam

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ PyJWT==2.6.0
 alembic==1.9.2
 gunicorn==22.0.0
 pg8000==1.31.2
-cloud-sql-python-connector==1.10.0
+cloud-sql-python-connector==1.11.0
 neptune==1.1.1
 matplotlib
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ sendgrid==6.11.0
 packaging==24.1
 pydantic==2.8.2
 pydantic-settings==2.3.4
+numpy==1.26.4

--- a/src/casp/services/db/__init__.py
+++ b/src/casp/services/db/__init__.py
@@ -1,6 +1,7 @@
 import pg8000
 import sqlalchemy.orm
 from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector.enums import RefreshStrategy
 from sqlalchemy.orm import declarative_base, sessionmaker
 
 from casp.services import settings
@@ -17,16 +18,18 @@ class PrivateConnectionProvider:
             user=settings.DB_USER,
             password=settings.DB_PASSWORD,
             db=settings.DB_NAME,
-            enable_iam_auth=False,
-            ip_type=IPTypes.PRIVATE,
         )
         return conn
 
 
 def create_engine() -> sqlalchemy.engine.base.Engine:
     if settings.DB_PRIVATE_IP is not None:
-        # initialize Cloud SQL Python Connector object
-        connector = Connector()
+        # initialize Cloud SQL Python Connector object with default settings for all connections
+        connector = Connector(
+            enable_iam_auth=False,
+            ip_type=IPTypes.PRIVATE,
+            refresh_strategy=RefreshStrategy.LAZY,
+        )
 
         return sqlalchemy.create_engine(
             url="postgresql+pg8000://",


### PR DESCRIPTION
This PR makes us create DB connections as needed as opposed to eagerly.  Managing connections eagerly seems to cause credential expiration errors - they are innocuous since the connection gets recreated but it spams our logs.  I've tested on my environment and it seems to make the exceptions disappear.