### PR TITLE
Chore: Update min client version to 1.5.1

### DIFF
--- a/src/casp/services/constants.py
+++ b/src/casp/services/constants.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 # The minimum client version that is allowed to connect to the server.
-MIN_CLIENT_VERSION: str = "1.4.13"
+MIN_CLIENT_VERSION: str = "1.5.1"
 
 
 class ContextKeys(str, Enum):


### PR DESCRIPTION
Enforcing all clients to update to version 1.5.1, as it includes the newer ontology. Version 1.4.13 does not include it because I mistakenly tagged the wrong commit on a client while trying to release 1.4.13.

Please refer to [this PR](https://github.com/cellarium-ai/cellarium-cas/pull/83) on the client repo for more details.