### PR TITLE
Fixed dependency issue causing "Create" pages on the admin dashboard to break

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+WTForms==3.1.2
 anndata~=0.8.0
 fastavro
 google-api-python-client

--- a/src/casp/services/admin/server.py
+++ b/src/casp/services/admin/server.py
@@ -1,4 +1,4 @@
 from casp.services.admin import flask_app
 
 if __name__ == "__main__":
-    flask_app.run(debug=True)
+    flask_app.run()

--- a/src/casp/services/admin/server.py
+++ b/src/casp/services/admin/server.py
@@ -1,4 +1,4 @@
 from casp.services.admin import flask_app
 
 if __name__ == "__main__":
-    flask_app.run()
+    flask_app.run(debug=True)


### PR DESCRIPTION
A dependency of a dependency had an update that appears to be broken, so now we'll explicitly specify the version of that dependency to use.