### PR TITLE
Fix for the timestamp bug

### DIFF
--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -168,7 +168,7 @@ class UserAdminView(CellariumCloudAdminModelView):
         "created_at",
     )
     column_editable_list = ("is_admin",)
-    form_excluded_columns = ("requests_processed", "cells_processed", "created_at")
+    form_excluded_columns = ("requests_processed", "cells_processed")
 
     inline_models = [
         (

--- a/src/casp/services/admin/views.py
+++ b/src/casp/services/admin/views.py
@@ -165,9 +165,10 @@ class UserAdminView(CellariumCloudAdminModelView):
         "lifetime_cell_quota",
         "total_requests_processed",
         "total_cells_processed",
+        "created_at",
     )
     column_editable_list = ("is_admin",)
-    form_excluded_columns = ("requests_processed", "cells_processed")
+    form_excluded_columns = ("requests_processed", "cells_processed", "created_at")
 
     inline_models = [
         (

--- a/src/casp/services/db/models/users.py
+++ b/src/casp/services/db/models/users.py
@@ -4,7 +4,6 @@ import enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import backref, column_property, deferred, relationship
-from sqlalchemy.sql import func
 
 from casp.services import db, settings
 
@@ -76,7 +75,9 @@ class UserKey(db.Base):
     id = sa.Column(sa.Integer, primary_key=True)
     key_locator = sa.Column(UUID, nullable=False, unique=True)
     user_id = sa.Column(sa.Integer, sa.ForeignKey(f"{User.__tablename__}.id"), nullable=False)
-    created_date = sa.Column(sa.DateTime, default=(lambda: datetime.datetime.now(datetime.timezone.utc)), nullable=False)
+    created_date = sa.Column(
+        sa.DateTime, default=(lambda: datetime.datetime.now(datetime.timezone.utc)), nullable=False
+    )
     active = sa.Column(sa.Boolean(), default=True, nullable=False)
     expires = sa.Column(
         sa.DateTime,

--- a/src/casp/services/db/models/users.py
+++ b/src/casp/services/db/models/users.py
@@ -4,6 +4,7 @@ import enum
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import backref, column_property, deferred, relationship
+from sqlalchemy.sql import func
 
 from casp.services import db, settings
 
@@ -22,7 +23,7 @@ class User(db.Base):
     cell_quota = sa.Column(sa.Integer(), default=100000, nullable=False)
     lifetime_cell_quota = sa.Column(sa.Integer(), default=settings.DEFAULT_LIFETIME_QUOTA, nullable=True)
     quota_increased = sa.Column(sa.Boolean(), default=False, nullable=False)
-    created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.now(datetime.timezone.utc))
+    created_at = sa.Column(sa.DateTime, nullable=False, default=(lambda: datetime.datetime.now(datetime.timezone.utc)))
     ask_for_feedback = sa.Column(sa.Boolean(), default=True, nullable=False)
 
     __tablename__ = "users_user"
@@ -44,7 +45,7 @@ class UserActivity(db.Base):
     cell_count = sa.Column(sa.Integer, default=0, nullable=False)
     model_name = sa.Column(sa.String(255), nullable=False)
     method = sa.Column(sa.String(255), nullable=True)
-    finished_time = sa.Column(sa.DateTime, default=datetime.datetime.now(datetime.timezone.utc))
+    finished_time = sa.Column(sa.DateTime, default=(lambda: datetime.datetime.now(datetime.timezone.utc)))
     event = sa.Column(sa.Enum(UserActivityEvent), nullable=False)
 
     __tablename__ = "users_useractivity"
@@ -75,7 +76,7 @@ class UserKey(db.Base):
     id = sa.Column(sa.Integer, primary_key=True)
     key_locator = sa.Column(UUID, nullable=False, unique=True)
     user_id = sa.Column(sa.Integer, sa.ForeignKey(f"{User.__tablename__}.id"), nullable=False)
-    created_date = sa.Column(sa.DateTime, default=datetime.datetime.now(datetime.timezone.utc), nullable=False)
+    created_date = sa.Column(sa.DateTime, default=(lambda: datetime.datetime.now(datetime.timezone.utc)), nullable=False)
     active = sa.Column(sa.Boolean(), default=True, nullable=False)
     expires = sa.Column(
         sa.DateTime,


### PR DESCRIPTION
For datetime columns on the user and user activity tables, we were setting the default to the result of calling datetime.now() once.  So it was basically only calling it the first time it checked for the default value and then only ever calling it again in new instances of the server (I think).  This resulted in a bunch of incorrect datetime values.  I've fixed it by replacing it with a lambda that calls datetime.now() each time a new user or user activity object is instantiated.